### PR TITLE
Change python to python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ parser.gen.c: parser.y lexer.gen.h
 parser.gen.h: parser.gen.c
 
 jv_utf8_tables.gen.h: gen_utf8_tables.py
-	python $^ > $@
+	python2 $^ > $@
 jv_unicode.c: jv_utf8_tables.gen.h
 
 version.gen.h: VERSION

--- a/gen_utf8_tables.py
+++ b/gen_utf8_tables.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 mask = lambda n: (1 << n) - 1
 


### PR DESCRIPTION
Arch Linux's `python` is Python 3. All distributions should accept `python2` to run Python 2.
