### PR TITLE
Allow manpage to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,13 @@ docs/content/2.download/source/jq.tgz: jq
 tarball: docs/content/2.download/source/jq.tgz
 
 jq.1: docs/content/3.manual/manual.yml
-	( cd docs; rake manpage; ) > $@
+	( cd docs; bundle exec rake manpage; ) > $@
 
 install: jq jq.1
 	install -d -m 0755 $(prefix)/bin
 	install -m 0755 jq $(prefix)/bin
 	install -d -m 0755 $(mandir)/man1
-	install -m 0755 jq.1 $(mandir)/man1
+	install -m 0644 jq.1 $(mandir)/man1
 
 uninstall:
 	rm -vf $(prefix)/bin/jq

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -4,6 +4,7 @@ require 'maruku'
 require 'json'
 require 'ronn'
 require 'tempfile'
+require 'yaml'
 
 module ExtraFilters
   def markdownify(input)


### PR DESCRIPTION
This is a tiny change to allow the manpage to be built.

Manpage doesn't build because a require is missing from the Rakefile (it is part of ruby stdlib, but must be require-d explictily.)

This executes rake in the context of the bundle, so it would be more forgiving about the environment (and also warn about needed gems not being installed)

Also fixed the incorrect execute permission on the manfile.
