### PR TITLE
Fix link typos in tutorial

### DIFF
--- a/docs/content/1.tutorial/default.yml
+++ b/docs/content/1.tutorial/default.yml
@@ -237,5 +237,5 @@ body:
       - - -
 
       Here endeth the tutorial! There's lots more to play with, go
-      read [the manual](../manual) if you're interested, and [download
-      jq](../download) if you haven't already.
+      read [the manual](manual) if you're interested, and [download
+      jq](download) if you haven't already.


### PR DESCRIPTION
The links at the bottom of http://stedolan.github.io/jq/tutorial ("go read the manual if you’re interested, and download jq if you haven’t already") are 404. I believe this would fix them, though I haven't tried it.
