### PR TITLE
Fix Github URLs: stedolan.github.com -> stedolan.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ jq
 jq is a command-line JSON processor.
 
 If you want to learn to use jq, read the documentation at
-[http://stedolan.github.com/jq](http://stedolan.github.com/jq). This
+[http://stedolan.github.io/jq](http://stedolan.github.io/jq). This
 documentation is generated from the docs/ folder of this repository.
 
 If you want to hack on jq, feel free, but be warned that its internals
 are not well-documented at the moment. Bring a hard hat and a
-shovel. Also, read the wiki: http://github.com/stedolan/jq/wiki
+shovel. Also, read the wiki: https://github.com/stedolan/jq/wiki
 
 To build jq, run
 

--- a/docs/content/2.download/default.yml
+++ b/docs/content/2.download/default.yml
@@ -31,7 +31,7 @@ body:
 
       ### OS X
 
-       * `brew install jq` using [homebrew](http://mxcl.github.com/homebrew/)
+       * `brew install jq` using [homebrew](http://mxcl.github.io/homebrew/)
 
        * Or, grab prebuilt [64-bit binaries](osx64/jq) or [32-bit
          binaries](osx32/jq)
@@ -72,7 +72,7 @@ body:
       On OS X, these are all included in Apple's command line tools, which
       can be installed from [Xcode](http://developer.apple.com/technologies/tools/).
       However, you may find that you need a newer version of Bison than the one provided
-      by Apple. This can be found in [Homebrew](http://mxcl.github.com/homebrew/)
+      by Apple. This can be found in [Homebrew](http://mxcl.github.io/homebrew/)
       or [MacPorts](http://macports.org/).
 
       `flex` and `bison` are used to generate the lexer and parser for

--- a/main.c
+++ b/main.c
@@ -20,13 +20,13 @@ static void usage() {
   fprintf(stderr, "For a description of the command line options and\n");
   fprintf(stderr, "how to write jq filters (and why you might want to)\n");
   fprintf(stderr, "see the jq manpage, or the online documentation at\n");
-  fprintf(stderr, "http://stedolan.github.com/jq\n\n");
+  fprintf(stderr, "http://stedolan.github.io/jq\n\n");
   exit(1);
 }
 
 static void die() {
   fprintf(stderr, "Use %s --help for help with command-line options,\n", progname);
-  fprintf(stderr, "or see the jq documentation at http://stedolan.github.com/jq\n");
+  fprintf(stderr, "or see the jq documentation at http://stedolan.github.io/jq\n");
   exit(1);
 }
 


### PR DESCRIPTION
This patch is against your `docs` branch (that is more recent than `master`).
