### PR TITLE
Case insensitive *_entries functions

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -562,8 +562,10 @@ static const char* const jq_builtins[] = {
   "def _modify(paths; update): reduce path(paths) as $p (.; setpath($p; getpath($p) | update));",
   "def recurse(f): ., (f | select(. != null) | recurse(f));",
   "def to_entries: [keys[] as $k | {key: $k, value: .[$k]}];",
-  "def from_entries: map({(.key): .value}) | add;",
+  "def to_entries_upper: [keys[] as $k | {Key: $k, Value: .[$k]}];",
+  "def from_entries: map({(.Key//.key): (.value//.Value)}) | add;",
   "def with_entries(f): to_entries | map(f) | from_entries;",
+  "def with_entries_upper(f): to_entries_upper | map(f) | from_entries;",
   "def reverse: [.[length - 1 - range(0;length)]];",
 };
 

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -515,7 +515,7 @@ sections:
             input: '[[0,1], ["a","b","c"]]'
             output: ['[false, true]']
 
-      - title: `to_entries`, `from_entries`, `with_entries`
+      - title: `to_entries`, `from_entries`, `with_entries, to_entries_upper, with_entries_upper`
         body: |
           
           These functions convert between an object and an array of
@@ -527,6 +527,10 @@ sections:
           `with_entries(foo)` is a shorthand for `to_entries |
           map(foo) | from_entries`, useful for doing some operation to
           all keys and values of an object.
+          
+          `to_entries_upper` and `with_entries_upper` function the same
+          as `to_entries` and `with_entries`, but will generate entries
+          with `Key` and `Value` instead of `key` and `value`.
 
         examples:
           - program: 'to_entries'


### PR DESCRIPTION
Some JSON includes entries as {"Key":"foo" , "Value":"bar"} instead of
{"key":"foo" , "value":"bar"}. This update makes from_entries handle
both forms.

It also adds to_entries_upper and with_entries_upper to output with
"Key" and "Value" instead of "key" and "value".
