### PR TITLE
Add jv_nomem, non-exception ENOMEM handling

### DIFF
--- a/jv.h
+++ b/jv.h
@@ -26,6 +26,12 @@ typedef struct {
   } val;
 } jv;
 
+extern jv jv_nomem;
+extern jv jv_nomem_str;
+
+#define IS_JV_NOMEM(a) \
+    ((a).kind == jv_nomem.kind && (a).val.nontrivial.ptr == jv_nomem.val.nontrivial.ptr)
+
 /*
  * All jv_* functions consume (decref) input and produce (incref) output
  * Except jv_copy


### PR DESCRIPTION
This way you can check the result of the last jv operation, and if it's
the same as jv_nomem then there was an ENOMEM event.  No need for
nomem_handlers, no need to longjmp() out.  Way simpler.
