### PR TITLE
Add missing -i flag in build instructions

### DIFF
--- a/docs/content/2.download/default.yml
+++ b/docs/content/2.download/default.yml
@@ -51,7 +51,7 @@ body:
 
           git clone https://github.com/stedolan/jq.git
           cd jq
-          autoreconf
+          autoreconf -i
           ./configure
           make
           sudo make install


### PR DESCRIPTION
README had the -i flag but not on the website.
