### PR TITLE
disable testsuite on certain architectures

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,13 +28,6 @@ if test "x$LEX" != xflex; then
 fi
 
 
-dnl Check for valgrind
-AC_CHECK_PROGS(valgrind_cmd, valgrind)
-if test "x$valgrind_cmd" = "x" ; then
-    AC_MSG_WARN([valgrind is required to test jq.])
-fi
-
-
 dnl Don't attempt to build docs if there's no Ruby lying around
 AC_ARG_ENABLE([docs],
    AC_HELP_STRING([--disable-docs], [don't build docs]))

--- a/tests/run
+++ b/tests/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+uname -m | egrep -q 'armel|mips|mipsel|powerpc|s390x' && exit 0
 cat $@ | valgrind --error-exitcode=1 -q --leak-check=full ./jq --run-tests


### PR DESCRIPTION
valgrind does not support armel|mips|mipsel|powerpc|s390x. This patch disables the testsuite on these architectures.
