### PR TITLE
Add a -j / --join-output option.

### DIFF
--- a/main.c
+++ b/main.c
@@ -56,6 +56,7 @@ enum {
   NO_COLOUR_OUTPUT = 128,
   SORTED_OUTPUT = 256,
   UNBUFFERED_OUTPUT = 4096,
+  JOIN_OUTPUT = 8192,
 
   FROM_FILE = 512,
 
@@ -88,7 +89,9 @@ static void process(jq_state *jq, jv value, int flags) {
       if (options & UNBUFFERED_OUTPUT) dumpopts |= JV_PRINT_UNBUFFERED;
       jv_dump(result, dumpopts);
     }
-    printf("\n");
+    if (!(options & JOIN_OUTPUT)) {
+      printf("\n");
+    }
   }
   jv_free(result);
 }
@@ -178,6 +181,8 @@ int main(int argc, char* argv[]) {
       options |= PROVIDE_NULL;
     } else if (isoption(argv[i], 'f', "from-file")) {
       options |= FROM_FILE;
+    } else if (isoption(argv[i], 'j', "join-output")) {
+      options |= JOIN_OUTPUT;
     } else if (isoption(argv[i], 0, "arg")) {
       if (i >= argc - 2) {
         fprintf(stderr, "%s: --arg takes two parameters (e.g. -a varname value)\n", progname);


### PR DESCRIPTION
I'm processing logfiles for [Docker](http://docker.io/); their JSON format looks like this:

``` js
{"log":"Sat Nov 16 18:44:01 UTC 2013\n","stream":"stdout","time":"2013-11-16T18:44:01.218661284Z"}
{"log":"Sat Nov 16 18:44:02 UTC 2013\n","stream":"stdout","time":"2013-11-16T18:44:02.222586697Z"}
```

I use `jq -r .log`, but the output includes blank lines. This trivial pull request adds a `-j / --join-output` option to remove the extra `\n` output by `jq` after processing each JS element.

I didn't find tests for output options; so let me know if I missed them and should write a test case for this (I might need some guidance then :-))

Thank you for making `jq`! 
