### PR TITLE
Make numbers use their original string representation if possible

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -55,7 +55,6 @@ static jv f_floor(jv input) {
     return type_error(input, "cannot be floored");
   }
   jv ret = jv_number(floor(jv_number_value(input)));
-  jv_free(input);
   return ret;
 }
 
@@ -64,7 +63,6 @@ static jv f_sqrt(jv input) {
     return type_error(input, "has no square root");
   }
   jv ret = jv_number(sqrt(jv_number_value(input)));
-  jv_free(input);
   return ret;
 }
 
@@ -73,7 +71,6 @@ static jv f_negate(jv input) {
     return type_error(input, "cannot be negated");
   }
   jv ret = jv_number(-jv_number_value(input));
-  jv_free(input);
   return ret;
 }
 
@@ -278,7 +275,7 @@ static jv f_format(jv input, jv fmt) {
         line = jv_string_concat(line, jv_dump_string(x, 0));
         break;
       case JV_KIND_NUMBER:
-        if (jv_number_value(x) != jv_number_value(x)) {
+        if (jv_number_value(jv_copy(x)) != jv_number_value(jv_copy(x))) {
           /* NaN, render as empty string */
           jv_free(x);
         } else {

--- a/jv.h
+++ b/jv.h
@@ -7,6 +7,7 @@ typedef enum {
   JV_KIND_FALSE,
   JV_KIND_TRUE,
   JV_KIND_NUMBER,
+  JV_KIND_NUMBER_S, // number with original string
   JV_KIND_STRING,
   JV_KIND_ARRAY,
   JV_KIND_OBJECT
@@ -55,7 +56,9 @@ jv jv_false();
 jv jv_bool(int);
 
 jv jv_number(double);
+jv jv_number_s(const char* str, double x);
 double jv_number_value(jv);
+const char* jv_number_str(jv);
 
 jv jv_array();
 jv jv_array_sized(int);

--- a/jv_aux.c
+++ b/jv_aux.c
@@ -437,7 +437,7 @@ int jv_cmp(jv a, jv b) {
     break;
 
   case JV_KIND_NUMBER: {
-    double da = jv_number_value(a), db = jv_number_value(b);
+    double da = jv_number_value(jv_copy(a)), db = jv_number_value(jv_copy(b));
     
     // handle NaN as though it were null
     if (da != da) r = jv_cmp(jv_null(), jv_number(db));

--- a/jv_parse.c
+++ b/jv_parse.c
@@ -276,7 +276,7 @@ static pfunc check_literal(struct jv_parser* p) {
     double d = jvp_strtod(&p->dtoa, p->tokenbuf, &end);
     if (end == 0 || *end != 0)
       return "Invalid numeric literal";
-    TRY(value(p, jv_number(d)));
+    TRY(value(p, jv_number_s(p->tokenbuf, d)));
   }
   p->tokenpos = 0;
   return 0;

--- a/jv_print.c
+++ b/jv_print.c
@@ -139,7 +139,13 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     put_str("true", F, S);
     break;
   case JV_KIND_NUMBER: {
-    double d = jv_number_value(x);
+    const char* number_str;
+    if ((number_str = jv_number_str(x))) {
+      put_str(number_str, F, S);
+      break;
+    }
+
+    double d = jv_number_value(jv_copy(x));
     if (d != d) {
       // JSON doesn't have NaN, so we'll render it as "null"
       put_str("null", F, S);


### PR DESCRIPTION
Doing any math (e.g. num+0) will change the representation.

This also fixes a bunch of jv_number memory management issues that matter now that numbers actually get allocated sometimes.

See issue #218 and #143