### PR TITLE
consistent use of goto out in main

### DIFF
--- a/main.c
+++ b/main.c
@@ -331,12 +331,8 @@ int main(int argc, char* argv[]) {
     }
   }
 out:
-  if(input_filenames != NULL){
-    jv_mem_free(input_filenames);
-  }
-  if(jq != NULL){
-    jq_teardown(&jq);
-  }
+  jv_mem_free(input_filenames);
+  jq_teardown(&jq);
   if (ret >= 10 && ret <= 11 && !(options & EXIT_STATUS))
     return 0;
   return ret;


### PR DESCRIPTION
This fixes the not terribly important issue that valgrind would complain about not having called jq_teardown leaving some memory hanging around. 
