### PR TITLE
Fix warnings about vprintf

### DIFF
--- a/locfile.c
+++ b/locfile.c
@@ -96,8 +96,8 @@ enomem:
   if (cb != NULL)
     cb(cb_data, jv_invalid());
   else if (errno == ENOMEM || errno == 0)
-    vfprintf(stderr, "Error formatting jq compilation error: %s", strerror(errno ? errno : ENOMEM));
+    fprintf(stderr, "Error formatting jq compilation error: %s", strerror(errno ? errno : ENOMEM));
   else
-    vfprintf(stderr, "Error formatting jq compilation error: %s", strerror(errno));
+    fprintf(stderr, "Error formatting jq compilation error: %s", strerror(errno));
   return;
 }


### PR DESCRIPTION
Another excitingly trivial pull request.

I think these vprintfs are meant to be printfs - their usage pattern looks like printf rather than vprintf and they're causing gcc to complain about wrong pointer types.
