### PR TITLE
Adding a .travis.yml file to use the travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+
+before_script:
+    - sudo apt-get install -qq valgrind
+    - bundle install --gemfile=docs/Gemfile
+    - autoreconf -i
+
+script:
+    - ./setup.sh
+    - ./configure && make
+
+compiler:
+    - gcc
+    - clang
+
+notifications:
+    email: false


### PR DESCRIPTION
From wikipedia:

Travis CI is a hosted, distributed continuous integration service used
to build and test projects hosted at GitHub.

Travis CI is configured by adding a file named .travis.yml, which is a
YAML format text file, to the root directory of the GitHub repository.

Travis CI automatically detects when a commit has been made and pushed
to a GitHub repository that is using Travis CI, and each time this
happens, it will try to build the project and run tests. This includes
commits to all branches, not just to the master branch. When that
process has completed, it will notify a developer in the way it has been
configured to do so — for example, by sending an email containing the
test results (showing success or failure), or by posting a message on an
IRC channel. It can be configured to run the tests on a range of
different machines, with different software installed (such as older
versions of a programming language, to test for compatibility).
