### PR TITLE
Ignore the config/test-driver file

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -6,3 +6,4 @@ install-sh
 ltmain.sh
 missing
 ylwrap
+test-driver


### PR DESCRIPTION
This file is automatically generated and does not need to be committed.
