### PR TITLE
Add link to jq playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ jq is a command-line JSON processor.
 If you want to learn to use jq, read the documentation at
 [http://stedolan.github.io/jq](http://stedolan.github.io/jq). This
 documentation is generated from the docs/ folder of this repository.
+You can also try it online at [http://jqplay.herokuapp.com](http://jqplay.herokuapp.com).
 
 If you want to hack on jq, feel free, but be warned that its internals
 are not well-documented at the moment. Bring a hard hat and a


### PR DESCRIPTION
I really like `jq` and built [a web interface for it](http://jqplay.herokuapp.com/) for my own convenience. It's open sourced in https://github.com/jingweno/jqplay. Hopefully it'll help other people too :smile_cat:.
