### PR TITLE
Add string parsing (builtin, test and doc).

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -586,6 +586,7 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_ltrimstr, "ltrimstr", 2},
   {(cfunction_ptr)f_rtrimstr, "rtrimstr", 2},
   {(cfunction_ptr)jv_string_split, "split", 2},
+  {(cfunction_ptr)jv_string_parse, "parse", 1},
   {(cfunction_ptr)jv_string_explode, "explode", 1},
   {(cfunction_ptr)jv_string_implode, "implode", 1},
   {(cfunction_ptr)jv_setpath, "setpath", 3}, // FIXME typechecking

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1075,6 +1075,17 @@ sections:
             input: '"a, b,c,d, e"'
             output: ['["a","b,c,d","e"]']
 
+      - title: `parse`
+        body: |
+
+          Parses an input string (a query string of a URL) to build
+          an object from it (with the key/values pairs).
+
+        examples:
+          - program: 'parse'
+            input: '"foo=bar&bonsai=%E7%9B%86%E6%99%AF"'
+            output: ['{"foo":"bar","bonsai":"盆景"}']
+
       - title: `recurse`
         body: |
           

--- a/jv.h
+++ b/jv.h
@@ -94,6 +94,7 @@ jv jv_string_fmt(const char*, ...);
 jv jv_string_append_codepoint(jv a, uint32_t c);
 jv jv_string_append_buf(jv a, const char* buf, int len);
 jv jv_string_append_str(jv a, const char* str);
+jv jv_string_parse(jv j);
 jv jv_string_split(jv j, jv sep);
 jv jv_string_explode(jv j);
 jv jv_string_implode(jv j);

--- a/tests/all.test
+++ b/tests/all.test
@@ -676,6 +676,21 @@ def inc(x): x |= .+1; inc(.[].a)
 ["a, bc, def, ghij, jklmn, a,b, c,d, e,f", "a,b,c,d, e,f,g,h"]
 [["a","bc","def","ghij","jklmn","a,b","c,d","e,f"],["a,b,c,d","e,f,g,h"]]
 
+parse
+"a=b&c=%64+%65&f=%E7%9B%86%E6%99%AF"
+{"a":"b","c":"d e","f":"盆景"}
+
+# rare or unexpected cases (and decisions taken to avoid errors)
+# missing equal sign ==> value is null
+# missing key ==> key is empty string
+# missing key, value and equal sign ==> empty reply
+# extra equals ==> incorporated in value
+# bad hexadecimal in %XY == %00XY when X is wrong; ==%0XY when Y is wrong
+
+[.[]|parse]
+["a&=b&c==d&error=%and+%recovery"]
+[{"a":null,"":"b","c":"=d","error":"\nnd \u0000recovery"}]
+
 [.[] * 3]
 ["a", "ab", "abc"]
 ["aaa", "ababab", "abcabcabc"]


### PR DESCRIPTION
Well, I had to process such a log file... where a value from a JSON object was a query to our server.

...
{"date":"2014/03/05 15:25:42","ip":"81.83.144.50","query":"version=2014_02_20&language=nl&UUID=BE7FE9D9-83E1-4117-9ECF-69AEA4FF4124&dev=iPad3%2C3&os=7.0.6"}
{"date":"2014/03/05 15:27:43","ip":"91.183.33.9","query":"version=2014_02_20&language=fr&UUID=494018D1-6CAF-4D99-906B-088A9F9DCD02&dev=iPhone3%2C1&OS=7.0.6"}
...

Adding "parse" (somehow related to "split") made my processing more "natural"...  I hope it helps.  Thanks for creating jq.
