### PR TITLE
Detect endianness at configuration with Autoconf AC_C_BIGENDIAN feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,12 @@ if test $have___thread = yes; then
 fi
 AC_MSG_RESULT($have___thread)
 
+AC_C_BIGENDIAN(
+   AC_DEFINE([IEEE_MC68k], 1, [machine is bigendian]),
+   AC_DEFINE([IEEE_8087], 1, [machine is littleendian]),
+   AC_MSG_ERROR(unknown endianess),
+   AC_MSG_ERROR(universial endianess not supported)
+)
 
 AC_SUBST([BUNDLER], ["$bundle_cmd"])
 

--- a/jv_dtoa.c
+++ b/jv_dtoa.c
@@ -187,7 +187,6 @@
  *	used for input more than STRTOD_DIGLIM digits long (default 40).
  */
 
-#define IEEE_8087
 #define NO_ERRNO
 #define NO_HEX_FP
 #define No_Hex_NaN


### PR DESCRIPTION
Currently IEEE_8087 (little endian) is defined as default in "jv_dtoa.c". From my understanding, to be able to use jq on big endian architecture you have to manually change this default define.

So to be able to use jq on bigendian architectures without changing code we need to be able to configure endianness. This patch does that.

FYI, compiling for bigendian, without changing the default define would result in numbers not being parsed correctly or even causing the jq application to hang.
