### PR TITLE
Add jq builtin reduce_keys(f)

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -914,6 +914,7 @@ static const char* const jq_builtins[] = {
   "def min(f): _min_by_impl(map([f]));",
   "def max_by(f): max(f);",
   "def min_by(f): min(f);",
+  "def reduce_keys(f): reduce .[] as $item ({}; .[($item|keys[])] += $item[] );",
 #include "libm.h"
   "def add: reduce .[] as $x (null; . + $x);",
   "def del(f): delpaths([path(f)]);",

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -948,6 +948,22 @@ sections:
             input: '[{"foo":1, "bar":10}, {"foo":3, "bar":100}, {"foo":1, "bar":1}]'
             output: ['[[{"foo":1, "bar":10}, {"foo":1, "bar":1}], [{"foo":3, "bar":100}]]']
 
+      - title: "`reduce_keys(.foo)`"
+        body: |
+
+          `reduce_keys(.foo)` takes as input an array of objects, and produces a single object with values of keys being the concatenation of each originial value of a same key
+
+        examples:
+          - program: 'jq 'reduce_keys(.)''
+            input: [{"test-a": 1}, {"test-a": 2},{"test-a": 3},{"test-b": 4},{"test-b": 5}]
+            output: {"test-a":6,"test-b":9}
+          - program: 'jq 'reduce_keys(.)''
+            input: [{"test-a": ["a"]}, {"test-a": ["b"]},{"test-a": ["c"]},{"test-b": ["x"]},{"test-b": ["y"]}]
+            output: {"test-a":["a","b","c"],"test-b":["x","y"]}
+          - program: 'jq 'reduce_keys(.)''
+            input: [{"test-a": "a"}, {"test-a": "b"},{"test-a": "c"},{"test-b": "x"},{"test-b": "y"}]
+            output: {"test-a":"abc","test-b":"xy"}
+
       - title: "`min`, `max`, `min(path_exp)`, `max(path_exp)`, `min_by(path_exp)`, `max_by(path_exp)`"
         body: |
 


### PR DESCRIPTION
reduce_keys(.foo) takes as input an array of objects, and produces a single object with values added for a same key 

Example :

        jq 'reduce_keys(.)'
Input	[{"test-a": 1}, {"test-a": 2},{"test-a": 3},{"test-b": 4},{"test-b": 5}]
Output	{"test-a":6,"test-b":9}

        jq 'reduce_keys(.)'
Input	[{"test-a": ["a"]}, {"test-a": ["b"]},{"test-a": ["c"]},{"test-b": ["x"]},{"test-b": ["y"]}]
Output	{"test-a":["a","b","c"],"test-b":["x","y"]}

        jq 'reduce_keys(.)'
Input	[{"test-a": "a"}, {"test-a": "b"},{"test-a": "c"},{"test-b": "x"},{"test-b": "y"}]
Output	{"test-a":"abc","test-b":"xy"}
