### PR TITLE
Make @uri format string produce uppercase hexadecimal digits instead of lowercase ones

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -413,7 +413,7 @@ static jv f_format(jv input, jv fmt) {
       if (ch < 128 && unreserved[ch]) {
         line = jv_string_append_buf(line, s, 1);
       } else {
-        line = jv_string_concat(line, jv_string_fmt("%%%02x", ch));
+        line = jv_string_concat(line, jv_string_fmt("%%%02X", ch));
       }
       s++;
     }

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1350,7 +1350,7 @@ sections:
           * `@uri`:
 
             Applies percent-encoding, by mapping all reserved URI
-            characters to a `%xx` sequence.
+            characters to a `%XX` sequence.
 
           * `@csv`:
 
@@ -1379,7 +1379,7 @@ sections:
           will produce the following output for the input
           `{"search":"what is jq?"}`:
 
-              "http://www.google.com/search?q=what%20is%20jq%3f"
+              "http://www.google.com/search?q=what%20is%20jq%3F"
 
           Note that the slashes, question mark, etc. in the URL are
           not escaped, as they were part of the string literal.

--- a/tests/all.test
+++ b/tests/all.test
@@ -67,13 +67,13 @@ null
 "\"<>&'\\\"\""
 "1,\"<>&'\"\"\""
 "&lt;&gt;&amp;&apos;&quot;"
-"%3c%3e%26'%22"
+"%3C%3E%26'%22"
 "'<>&'\\''\"'"
 "PD4mJyI="
 
 @uri
 "\u03bc"
-"%ce%bc"
+"%CE%BC"
 
 @html "<b>\(.)</b>"
 "<script>hax</script>"


### PR DESCRIPTION
According to [RFC 3986](http://tools.ietf.org/html/rfc3986) on percent encoding, uppercase hexadecimal digits are recommended:

> The uppercase hexadecimal digits 'A' through 'F' are equivalent to
>    the lowercase digits 'a' through 'f', respectively.  If two URIs
>    differ only in the case of hexadecimal digits used in percent-encoded
>    octets, they are equivalent.  **For consistency, URI producers and
>    normalizers should use uppercase hexadecimal digits for all percent-
>    encodings.**

There are also usage cases where only uppercase hexadecimal digits are allowed, e.g., in parts of the Twitter API ([Percent encoding parameters](https://dev.twitter.com/docs/auth/percent-encoding-parameters)).

See issue https://github.com/stedolan/jq/issues/451 for details.

The code is super easy to fix — simply changed `jv_string_fmt("%%%02x", ch)` to `jv_string_fmt("%%%02X", ch)` and everything should work. Test suite and manual are also updated to reflect this change.
