### PR TITLE
Fix invalid YAML in manual.yml (quote grave accents starting scalars)

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1632,7 +1632,7 @@ sections:
             input: 'true'
             output: ['"some exception"']
 
-      - title: `?` operator
+      - title: "`?` operator"
         body: |
 
           The `?` operator, used as `EXP?`, is shorthand for `try EXP`.
@@ -1816,7 +1816,7 @@ sections:
             input: '[10,2,5,3]'
             output: ['20']
 
-      - title: `limit(n; exp)`
+      - title: "`limit(n; exp)`"
         body: |
 
           The `limit` function extracts up to `n` outputs from `exp`.
@@ -1826,7 +1826,7 @@ sections:
             input: '[0,1,2,3,4,5,6,7,8,9]'
             output: ['[0,1,2]']
 
-      - title: `foreach`
+      - title: "`foreach`"
         body: |
 
           The `foreach` syntax is similar to `reduce`, but intended to


### PR DESCRIPTION
Grave accent `"`"` is a reserved indicator in YAML per
http://www.yaml.org/spec/1.2/spec.html#id2774228, so it can't start a
plain scalar. This commit applies quoting to titles beginning with
grave accents.

---

Note that `syck` might tolerate the invalid `manual.yml` (not sure), but `psych` won't, and upon making the following errors will be reported:

```
rake aborted!
(<unknown>): found character that cannot start any token while scanning for the next token at line 1635 column 16
.../jq/docs/Rakefile:91:in `load_manual'
.../jq/docs/Rakefile:96:in `block (2 levels) in <top (required)>'
.../jq/docs/Rakefile:95:in `block in <top (required)>'
.../.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `eval'
.../.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => manpage
(See full trace by running task with --trace)
make[1]: *** [jq.1] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
```

where line 1635 is

``` yaml
      - title: `?` operator
```
