### PR TITLE
Add tests/all.trs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+tests/all.trs
 
 cscope.in.out
 cscope.out


### PR DESCRIPTION
Not sure if it's just me, but `tests/all.trs` is an auto generated junk during `make check`, whose content is (when `make check` is successful)

```
:test-result: PASS
:global-test-result: PASS
:recheck: no
:copy-in-global-log: no
```
