### PR TITLE
Fixing crash when a library's dependency could not be loaded.

### DIFF
--- a/linker.c
+++ b/linker.c
@@ -128,8 +128,6 @@ static int process_dependencies(jq_state *jq, jv lib_origin, block *src_block, s
       nerrors += load_library(jq, lib_path, &dep_def_block, lib_state);
       if (nerrors == 0)
         bk = block_bind_library(dep_def_block, bk, OP_IS_CALL_PSEUDO, jv_string_value(as));
-      else
-        block_free(dep_def_block);
     }
     jv_free(as);
   }


### PR DESCRIPTION
When a library's dependency could not be found, that library's blocks would get `block_free()`'d twice.  Once in `process_dependencies()` and again in `load_program()`.  We remove the `block_free()` in `process_dependencies()` and let `load_program()` handle cleanup.
