### PR TITLE
MinGW doesn't contain mkstemp(), fixing.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ AC_CHECK_PROGS(valgrind_cmd, valgrind)
 if test "x$valgrind_cmd" = "x" ; then
     AC_MSG_WARN([valgrind is required to test jq.])
 fi
-AC_CHECK_FUNCS(memmem)
+AC_CHECK_FUNCS([memmem mkstemp])
 
 
 dnl Don't attempt to build docs if there's no Ruby lying around

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "compile.h"
+#include "util.h"
 #include "jv.h"
 #include "jq.h"
 #include "jv_alloc.h"
@@ -381,7 +382,7 @@ int main(int argc, char* argv[]) {
     t = jv_mem_alloc(tlen);
     int n = snprintf(t, tlen,"%sXXXXXX", input_filenames[0]);
     assert(n > 0 && (size_t)n < tlen);
-    if (mkstemp(t) == -1) {
+    if (_jq_mkstemp(t) == -1) {
       fprintf(stderr, "Error: %s creating temporary file", strerror(errno));
       exit(3);
     }

--- a/util.c
+++ b/util.c
@@ -4,9 +4,20 @@
 #include <string.h>
 #endif
 #include <assert.h>
+
+
 #ifndef WIN32
 #include <pwd.h>
 #endif
+
+
+// Things needed for mkstemp replacement
+#ifndef HAVE_MKSTEMP
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <limits.h>
@@ -116,5 +127,16 @@ not_this:
   }
   return NULL;
 #endif /* !HAVE_MEMMEM */
+}
+
+int _jq_mkstemp(char *template) {
+#ifdef HAVE_MKSTEMP
+  return mkstemp(template);
+#else
+  char *filename = mktemp(template);
+  if (!filename)
+    return -1;
+  return open(filename, O_RDWR | O_CREAT, 0600);
+#endif /* !HAVE_MKSTEMP */
 }
 

--- a/util.h
+++ b/util.h
@@ -9,6 +9,7 @@ jv jq_realpath(jv);
 
 const void *_jq_memmem(const void *haystack, size_t haystacklen,
                        const void *needle, size_t needlelen);
+int _jq_mkstemp(char *template);
 
 #ifndef MIN
 #define MIN(a,b) \


### PR DESCRIPTION
Handle this generically in case _any_ platform doesn't contain it.