### PR TITLE
Missing brackets in the manual

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -712,7 +712,7 @@ sections:
             output: ['[5,3,7]']
           - program: '.[] | select(.id == "second")'
             input: '[{"id": "first", "val": 1}, {"id": "second", "val": 2}]'
-            output: '{"id": "second", "val": 2}'
+            output: ['{"id": "second", "val": 2}']
 
 
       - title: "`arrays`, `objects`, `iterables`, `booleans`, `numbers`, `strings`, `nulls`, `values`, `scalars`"


### PR DESCRIPTION
Trying to build the manual after 89545ea results in the following error:

```
rake aborted!
undefined method `join' for "{\"id\": \"second\", \"val\": 2}":String
/home/lcd047/tmp/jq/docs/Rakefile:111:in `block (5 levels) in <top (required)>'
/home/lcd047/tmp/jq/docs/Rakefile:108:in `each'
/home/lcd047/tmp/jq/docs/Rakefile:108:in `block (4 levels) in <top (required)>'
/home/lcd047/tmp/jq/docs/Rakefile:104:in `each'
/home/lcd047/tmp/jq/docs/Rakefile:104:in `block (3 levels) in <top (required)>'
/home/lcd047/tmp/jq/docs/Rakefile:99:in `each'
/home/lcd047/tmp/jq/docs/Rakefile:99:in `block (2 levels) in <top (required)>'
/home/lcd047/tmp/jq/docs/Rakefile:95:in `block in <top (required)>'
Tasks: TOP => manpage
(See full trace by running task with --trace)
make[1]: *** [jq.1] Error 1
make[1]: Leaving directory `/home/lcd047/tmp/jq'                                                                                
make: *** [all] Error 2
```

The patch below seems to address the problem.
