### PR TITLE
libm.h: comment j0, j1, y0 and y1

### DIFF
--- a/libm.h
+++ b/libm.h
@@ -10,8 +10,8 @@ LIBM_DD(cosh)
 LIBM_DD(exp2)
 LIBM_DD(exp)
 LIBM_DD(floor)
-LIBM_DD(j0)
-LIBM_DD(j1)
+/* LIBM_DD(j0) */
+/* LIBM_DD(j1) */
 LIBM_DD(log10)
 LIBM_DD(log2)
 LIBM_DD(log)
@@ -21,8 +21,8 @@ LIBM_DD(sqrt)
 LIBM_DD(tan)
 LIBM_DD(tanh)
 LIBM_DD(tgamma)
-LIBM_DD(y0)
-LIBM_DD(y1)
+/* LIBM_DD(y0) */
+/* LIBM_DD(y1) */
 /* LIBM_DID(jn) */
 /* LIBM_DID(yn) */
 /* LIBM_DDD(pow) */


### PR DESCRIPTION
Those functions are currently not used by jq, but having them in
libm.h prevents building with the uClibc C library when it doesn't
have DO_XSI_MATH option enabled.

This issue was spotted by the Buildroot autobuilder system:

  http://autobuild.buildroot.org/results/aaf/aaf3c114e0ca3e265ae32c646ba67f01aaf608bd/build-end.log

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>