### PR TITLE
Updated v1.3 filenames for Windows

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -108,7 +108,7 @@
 <ul>
 <li>jq 1.4 executables for <a href='win64/jq.exe'>64-bit</a> or <a href='win32/jq.exe'>32-bit</a></li>
 
-<li>jq 1.3 executables for <a href='win64/jq-1.3/jq.exe'>64-bit</a> or <a href='win32/jq-1.3/jq.exe'>32-bit</a></li>
+<li>jq 1.3 executables for <a href='win64/jq-1.3/jq-1.3.exe'>64-bit</a> or <a href='win32/jq-1.3/jq-1.3.exe'>32-bit</a></li>
 </ul>
 
 <h3 id='from_source_on_linux_os_x_cygwin_and_other_posixlike_operating_systems'>From source on Linux, OS X, Cygwin, and other POSIX-like operating systems</h3>


### PR DESCRIPTION
The jq 1.3 filenames for Windows are jq-1.3.exe instead of jq.exe. Updated these so they no longer return a 404.