### PR TITLE
Simple TSV output format

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1428,6 +1428,12 @@ sections:
             with double quotes for strings, and quotes escaped by
             repetition.
 
+          * `@tsv`:
+
+            The input must be an array, and it is rendered as TSV
+            (tab-separated values) file. Fields that contain tabs or newlines
+            are not escaped.
+
           * `@sh`:
 
             The input is escaped suitable for use in a command-line


### PR DESCRIPTION
I've added a `@tsv` output filter by copying the `@csv` filter. It outputs into TSV (tab-separated values) file. Some people have asked for this on #48 .

I haven't done anything with string escaping, because (a) I'm not sure how to use `escape_string`, and (b) I'm unsure what "the standard" TSV approach is. I think many unix tools don't escape tabs.
