### PR TITLE
Enhance from_entries to better deal with Amazon AWS Tags

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -1036,7 +1036,7 @@ static const char* const jq_builtins[] = {
   "def recurse_down: recurse;",
 
   "def to_entries: [keys_unsorted[] as $k | {key: $k, value: .[$k]}];",
-  "def from_entries: map({(.key // .Key): (.value // .Value)}) | add | .//={};",
+  "def from_entries: map({(.key // .Key // .Name): (.value // .Value)}) | add | .//={};",
   "def with_entries(f): to_entries | map(f) | from_entries;",
   "def reverse: [.[length - 1 - range(0;length)]];",
   "def indices($i): if type == \"array\" and ($i|type) == \"array\" then .[$i]"

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -738,7 +738,8 @@ sections:
           `from_entries` does the opposite conversion, and
           `with_entries(foo)` is a shorthand for `to_entries |
           map(foo) | from_entries`, useful for doing some operation to
-          all keys and values of an object.
+          all keys and values of an object. `from_entries` accepts key, Key,
+          Name, value and Value as keys.
 
         examples:
           - program: 'to_entries'

--- a/tests/all.test
+++ b/tests/all.test
@@ -1035,7 +1035,11 @@ to_entries
 [{"key":"a", "value":1}, {"key":"b", "value":2}]
 
 from_entries
-[{"key":"a", "value":1}, {"key":"b", "value":2}]
+[{"key":"a", "value":1}, {"Key":"b", "value":2}]
+{"a": 1, "b": 2}
+
+from_entries
+[{"key":"a", "Value":1}, {"Name":"b", "value":2}]
 {"a": 1, "b": 2}
 
 with_entries(.key |= "KEY_" + .)


### PR DESCRIPTION
AWS Tags use a structure of { "Name" : "key", "Value" : "value" }

This change enhances from_entries to allow Name as the key name.  Also included is an enhancement to the documentation to better describe from_entries, and a test to ensure it works.