### PR TITLE
Fix oniguruma detection logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ if test $ONIGURUMAPATHSET == 1; then
 fi
 
 # check for ONIGURUMA library
-HAVE_ONIGURUMA=1
+HAVE_ONIGURUMA=0
 AC_CHECK_HEADER("oniguruma.h",
     AC_CHECK_LIB([onig],[onig_version],[LIBS="$LIBS -lonig"; HAVE_ONIGURUMA=1;]))
 


### PR DESCRIPTION
At the moment, a failed oniguruma header check would leave
HAVE_ONIGURUMA set to 1 still, resulting in a compiler error
in builtin.c.