### PR TITLE
Correct automake and autoconf version requirements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,9 +7,9 @@ m4_include([m4/ax_compare_version.m4])
 m4_include([m4/ax_prog_bison_version.m4])
 
 dnl Created autoconf implementation thompson@dtosolutions, 26NOV12
-AC_PREREQ([2.61])
+AC_PREREQ([2.64])
 AC_CONFIG_AUX_DIR([config])
-AM_INIT_AUTOMAKE([parallel-tests foreign -Wall])
+AM_INIT_AUTOMAKE([1.11.2 parallel-tests foreign -Wall])
 AM_SILENT_RULES([yes])
 AM_PROG_AR
 AM_MAINTAINER_MODE([enable])


### PR DESCRIPTION
I've tried to compile jq from the GitHub sources on Scientific Linux 6.6 and encountered a problem with generating the ./configure script using `autoreconf -i`. As it turns out, the m4_esyscmd_s and AM_PROG_AR macros used in [configure.ac](https://github.com/stedolan/jq/blob/1e5e9f3ef871aae51f2817d7a577aa849fccc530/configure.ac) are not available for autoconf 2.63 and automake 1.11.1 - the most recent versions for this particular distro release (and also for CentOS 6.6 and probably other RHEL 6.6 distributions, too) . However, compiling from the source tarball available from the [jq download page](https://stedolan.github.io/jq/download/) works fine. 

The missing [AM_PROG_AR gets added in automake 1.11.2](https://lists.gnu.org/archive/html/info-gnu/2011-12/msg00008.html) and [m4_esyscmd_s gets added in autoconf 2.64](https://lists.gnu.org/archive/html/autotools-announce/2009-07/msg00000.html). I'm sending you a pull request that reflects these requirements in the configure.ac file.