### PR TITLE
detect and report output writing errors

### DIFF
--- a/main.c
+++ b/main.c
@@ -476,6 +476,11 @@ int main(int argc, char* argv[]) {
   if (jq_util_input_open_errors(input_state) != 0 && ret == 0 && (options & EXIT_STATUS))
     ret = 2;
 
+  if (fclose(stdout)!=0) {
+    fprintf(stderr,"Error: writing output failed: %s\n", strerror(errno));
+    ret = 2;
+  }
+
   if (ret != 0)
     goto out;
 


### PR DESCRIPTION
Detect output errors when the program exits.

Currently:
    $ echo '{}' | jq . > /dev/full && echo ok
    ok

with the patch:
    $ echo '{}' | jq . > /dev/full && echo ok
    Error: writing output failed: No space left on device

also apply to hardware/network/other I/O errors.

(replaces #714)