### PR TITLE
exit with non-zero code on runtime exceptions

### DIFF
--- a/main.c
+++ b/main.c
@@ -132,6 +132,7 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
       msg = jv_dump_string(msg, 0);
       fprintf(stderr, "jq: error (not a string): %s\n", jv_string_value(msg));
     }
+    ret = 5;
     jv_free(msg);
   }
   jv_free(result);


### PR DESCRIPTION
With this change, runtime exceptions are propagated to non-zero exit
code of 'jq', allow better scripting and automation. The new exit code
value is 5.

This allows using the shell's and/or operations ('&&' and '||') to
detect input runtime exceptions.

Before:
runtime exceptions are printed to STDERR, but not reported as non-zero exit-code:
    $ echo '"hello"' | jq '.|tonumber' ; echo $?
    jq: error: Invalid numeric literal at EOF at line 1, column 5 (while parsing 'hello')
    0

After:
    $ echo '"hello"' | ./jq '.|tonumber' ;  echo $?
    jq: error: Invalid numeric literal at EOF at line 1, column 5 (while parsing 'hello')
    5

Note that there's a subtle interplay when using "-e" option.
The value of the non-zero exit code changes from 4 to 5, but it still
indicates a 'failure' or non-true value.

Before:
    $ echo '"hello"' | jq -e '.|tonumber' ;  echo $?
    jq: error: Invalid numeric literal at EOF at line 1, column 5 (while parsing 'hello')
    4

After:
    $ echo '"hello"' | ./jq -e '.|tonumber' ;  echo $?
    jq: error: Invalid numeric literal at EOF at line 1, column 5 (while parsing 'hello')
    5