### PR TITLE
always propagate input errors to exit code

### DIFF
--- a/main.c
+++ b/main.c
@@ -474,7 +474,7 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  if (jq_util_input_open_errors(input_state) != 0 && ret == 0 && (options & EXIT_STATUS))
+  if (jq_util_input_open_errors(input_state) != 0)
     ret = 2;
 
   if (ret != 0)


### PR DESCRIPTION
Improve robustness in automated system when using exit code in shell scripts,
by exiting with code 2 if there was any input error (even overriding other
possible error exit codes).
Exit code 2 is already used to indicate system errors.

Without the patch:
   $ jq . no-such-file ; echo $?
   jq: no-such-file: No such file or directory
   0

With the patch:
   $ jq . no-such-file ; echo $?
   jq: no-such-file: No such file or directory
   2