### PR TITLE
Building `jq` inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:wheezy
+
+# get dependencies
+
+RUN apt-get update
+
+RUN apt-get install -y build-essential
+RUN apt-get install -y autoconf
+RUN apt-get install -y libonig2
+RUN apt-get install -y libtool
+RUN apt-get install -y git
+RUN apt-get install -y valgrind
+RUN apt-get install -y bison
+RUN apt-get install -y flex
+RUN apt-get install -y ruby1.9.3
+
+RUN gem install bundler
+
+# get docs dependencies
+
+COPY ./docs/Gemfile /app/docs/Gemfile
+COPY ./docs/Gemfile.lock /app/docs/Gemfile.lock
+
+WORKDIR /app/docs
+
+RUN bundle install
+
+# copy files
+
+WORKDIR /app
+
+COPY . /app
+
+# build
+
+RUN autoreconf -i
+RUN ./configure
+RUN make -j8
+RUN make check


### PR DESCRIPTION
I've created a simple `Dockerfile` that builds `jq`. We could use this to provide nightly versions easily or to ease using `master` for those scared of compiling by themselves. We could even set up a cross-compiling environment inside!

Getting a compiled `jq` from this branch should just a matter of running:

```sh
git checkout jq-1.4 # read notes below as of why
docker build -t jq .
docker run --name jq-container jq
docker cp jq-container:/app/jq .
```

(Or so I hope! Please report any issues you find)

Some things that could be problematic:

* Right now, it doesn't build static binaries. It probably should, right? We don't want it linking to the versions inside the Docker machine.
* It seems to build jq-1.4 just fine, but tests fail on `master` as of the time of this writing. Not sure if this is an issue with my Dockerfile or with the latest version of these tests.
* It needs `--disable-maintainer-mode` to be added to the `RUN ./configure` step in order to build `master` because `bison`'s needed version is not available on stable Debian version. This is probably just a matter of adding the right repository.

Anyway, I just want to leave this here as a proposal. Discuss! :)