### PR TITLE
@tsv: escape \r, \n, \\

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -383,7 +383,7 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
       assert(!strcmp(fmt_s, "tsv"));
       quotes = "";
       sep = "\t";
-      escapings = "\t\\t\0";
+      escapings = "\t\\t\0\r\\r\0\n\\n\0\\\\\\\0";
     }
     jv_free(fmt);
     if (jv_get_kind(input) != JV_KIND_ARRAY)

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1562,7 +1562,12 @@ sections:
           * `@tsv`:
 
             The input must be an array, and it is rendered as TSV
-            with tabs escaped as `\t`.
+            (tab-separated values). Each input array will be printed as
+            a single line. Fields are separated by a single
+            tab (ascii `0x09`). Input characters line-feed (ascii `0x0a`),
+            carriage-return (ascii `0x0d`), tab (ascii `0x09`) and
+            backslash (ascii `0x5c`) will be output as escape sequences
+            `\n`, `\r`, `\t`, `\\` respectively.
 
           * `@sh`:
 


### PR DESCRIPTION
When using '@tsv' output format with '-r' option,
escape \r, \n and \\ in addition to \t.

Example:
    $ printf '{"id":"hello\\ttab\\nworld","x":43 }' | jq .
    {
      "id": "hello\ttab\nworld",
      "x": 43
    }

Before: newlines are not escaped, generating invalid TSV output:

    $ printf '{"id":"hello\\ttab\\nworld","x":43 }' \
        | ./jq-old -r '[.id,.x] | @tsv'
    hello\ttab
    world	43

After: newlines are properly escaped:

    $ printf '{"id":"hello\\ttab\\nworld","x":43 }' \
        | ./jq-new -r '[.id, .x] | @tsv'
    hello\ttab\nworld	43

Before: backslashes themselves are not escaped, so there's no way to
distinguish between escaped characters and 'real' backslashes
(in the example below, there is should not be newline, despite the
output containing "\n".

    $ printf '{"x":"hello\\ttab\\\\new world"}' \
        | ./jq-old -r '[.x]|@tsv'
    hello\ttab\new world

After: backslashes are escaped:

    $ printf '{"x":"hello\\ttab\\\\new world"}' \
        | ./jq-new -r '[.x]|@tsv'
    hello\ttab\\new world