### PR TITLE
report filename:line on runtime errors

### DIFF
--- a/jq.h
+++ b/jq.h
@@ -47,5 +47,6 @@ int jq_util_input_open_errors(jq_util_input_state);
 int jq_util_input_read_more(jq_util_input_state);
 jv jq_util_input_next_input(jq_util_input_state);
 jv jq_util_input_next_input_cb(jq_state *, void *);
+jv jq_util_input_get_position(jq_state*);
 
 #endif /* !_JQ_H_ */

--- a/main.c
+++ b/main.c
@@ -126,13 +126,17 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
   if (jv_invalid_has_msg(jv_copy(result))) {
     // Uncaught jq exception
     jv msg = jv_invalid_get_msg(jv_copy(result));
+    jv input_pos = jq_util_input_get_position(jq);
     if (jv_get_kind(msg) == JV_KIND_STRING) {
-      fprintf(stderr, "jq: error: %s\n", jv_string_value(msg));
+      fprintf(stderr, "jq: error (at %s): %s\n",
+              jv_string_value(input_pos), jv_string_value(msg));
     } else {
       msg = jv_dump_string(msg, 0);
-      fprintf(stderr, "jq: error (not a string): %s\n", jv_string_value(msg));
+      fprintf(stderr, "jq: error (at %s) (not a string): %s\n",
+              jv_string_value(input_pos), jv_string_value(msg));
     }
     ret = 5;
+    jv_free(input_pos);
     jv_free(msg);
   }
   jv_free(result);


### PR DESCRIPTION
On runtime errors (ending in invalid state at 'main.c:process()'),
print the input filename and current line number which triggered the
error.

* util.c:
  struct jq_util_input_state: add variables
  jq_util_input_init(): initialize new variables
  jq_util_input_read_more(): update current file/line number on
                             `fgets()` calls.
  jq_util_input_get_position(): helper functions returning a JV_STRING
                                containing the current file/line.
  strncpyz(): helper function for safe string copy

* main.c:
  process(): upon invalid result ('uncaught jq exception'), get the
             current input position and print it to stderr.

* jq.h: declare 'jq_input_get_position()'.

With this patch, runtime errors printed to stderr will contain the
filename and line of the offending input.

Examples:

With stdin and multiple lines:

    $ printf '{"a":43}\n{"a":{"b":66}}\n' | ./jq '.a+1'
    44
    jq: error (at stdin:2): object and number cannot be added

With multiple files:

    $ printf '{"a":43}' > 1.json
    $ printf '{"a":"hello"}\n' > 2.json
    $ printf '{"a":{"b":66}}\n' > 3.json
    $ ./jq '[.a]|@tsv' 1.json 2.json 3.json
    "43"
    "hello"
    jq: error (at 3.json:1): object is not valid in a csv row

With very long lines (spanning multiple `fgets` calls):

    $ (  printf '{"a":43}\n' ;
         printf '{"a":{"b":[' ; seq 10000 | paste -d, -s | tr -d '\n' ;
         printf ']}}\n' ;
         printf '{"a":"hello"}\n' ) | ./jq '[.a] | @tsv'
    "43"
    jq: error (at stdin:2): object is not valid in a csv row
    "hello"

With raw input:

    $ seq 1000 | ./jq --raw-input 'select(.=="700") | . + 10'
    jq: error (at stdin:700): string and number cannot be added

Caveat:
The reported line will be the last line of the (valid) parsed JSON data.
Example:

    $ printf '{\n"a":\n"hello"\n\n\n}\n' | ./jq '.a+4'
    jq: error (at stdin:6): string and number cannot be added

minor ugly hack:
The call the get the current filename/line in 'main.c' is hard-coded
to 'jq_util_input_get_position()' which somewhat bypasses the idea
of using an input callback (e.g. 'jq_set_input_cb()').
But since similar calls to 'jq_utl_input_XXXX' are also hard-coded in
'main.c', the input callback mechanism isn't really generatic at the moment.