### PR TITLE
Current file function

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -1122,6 +1122,12 @@ static jv f_now(jq_state *jq, jv a) {
 }
 #endif
 
+static jv f_current_filename(jq_state *jq) {
+  return jq_util_input_get_current_filename(jq);
+}
+static jv f_current_line(jq_state *jq) {
+  return jq_util_input_get_current_line(jq);
+}
 
 #define LIBM_DD(name) \
   {(cfunction_ptr)f_ ## name, "_" #name, 1},
@@ -1186,6 +1192,8 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_mktime, "mktime", 1},
   {(cfunction_ptr)f_gmtime, "gmtime", 1},
   {(cfunction_ptr)f_now, "now", 1},
+  {(cfunction_ptr)f_current_filename, "filename", 1},
+  {(cfunction_ptr)f_current_line, "line", 1},
 };
 #undef LIBM_DD
 

--- a/jq.h
+++ b/jq.h
@@ -47,5 +47,6 @@ int jq_util_input_open_errors(jq_util_input_state);
 int jq_util_input_read_more(jq_util_input_state);
 jv jq_util_input_next_input(jq_util_input_state);
 jv jq_util_input_next_input_cb(jq_state *, void *);
+jv jq_util_input_get_position(jq_state*);
 
 #endif /* !_JQ_H_ */

--- a/jq.h
+++ b/jq.h
@@ -48,5 +48,7 @@ int jq_util_input_read_more(jq_util_input_state);
 jv jq_util_input_next_input(jq_util_input_state);
 jv jq_util_input_next_input_cb(jq_state *, void *);
 jv jq_util_input_get_position(jq_state*);
+jv jq_util_input_get_current_filename(jq_state*);
+jv jq_util_input_get_current_line(jq_state*);
 
 #endif /* !_JQ_H_ */

--- a/main.c
+++ b/main.c
@@ -126,13 +126,17 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
   if (jv_invalid_has_msg(jv_copy(result))) {
     // Uncaught jq exception
     jv msg = jv_invalid_get_msg(jv_copy(result));
+    jv input_pos = jq_util_input_get_position(jq);
     if (jv_get_kind(msg) == JV_KIND_STRING) {
-      fprintf(stderr, "jq: error: %s\n", jv_string_value(msg));
+      fprintf(stderr, "jq: error (at %s): %s\n",
+              jv_string_value(input_pos), jv_string_value(msg));
     } else {
       msg = jv_dump_string(msg, 0);
-      fprintf(stderr, "jq: error (not a string): %s\n", jv_string_value(msg));
+      fprintf(stderr, "jq: error (at %s) (not a string): %s\n",
+              jv_string_value(input_pos), jv_string_value(msg));
     }
     ret = 5;
+    jv_free(input_pos);
     jv_free(msg);
   }
   jv_free(result);

--- a/util.c
+++ b/util.c
@@ -308,6 +308,24 @@ jv jq_util_input_get_position(jq_state *jq) {
   return v;
 }
 
+jv jq_util_input_get_current_filename(jq_state* jq) {
+  jq_input_cb cb=NULL;
+  void *cb_data=NULL;
+  jq_get_input_cb(jq, &cb, &cb_data);
+  jq_util_input_state s = (jq_util_input_state)cb_data;
+  jv v = jv_string(s->current_filename);
+  return v;
+}
+
+jv jq_util_input_get_current_line(jq_state* jq) {
+  jq_input_cb cb=NULL;
+  void *cb_data=NULL;
+  jq_get_input_cb(jq, &cb, &cb_data);
+  jq_util_input_state s = (jq_util_input_state)cb_data;
+  jv v = jv_number(s->current_line);
+  return v;
+}
+
 
 // Blocks to read one more input from stdin and/or given files
 // When slurping, it returns just one value


### PR DESCRIPTION
based on previous patch (#752), this adds 'filename' and 'line' built-in
functions to jq (discussed in #743).

Example:

    $ printf '{"a":1}\n{"a":2}\n' > 4.json
    $ printf '{"a":"hello"}\n' > 5.json
    $ ./jq '{ "file":filename, "line":line, "value":.a }' 4.json 5.json
    {
      "file": "4.json",
      "line": 1,
      "value": 1
    }
    {
      "file": "4.json",
      "line": 2,
      "value": 2
    }
    {
      "file": "5.json",
      "line": 1,
      "value": "hello"
    }