### PR TITLE
print offending object in runtime error messages

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -22,18 +22,25 @@
 
 
 static jv type_error(jv bad, const char* msg) {
-  jv err = jv_invalid_with_msg(jv_string_fmt("%s %s",
+  char errbuf[15];
+  jv err = jv_invalid_with_msg(jv_string_fmt("%s (%s) %s",
                                              jv_kind_name(jv_get_kind(bad)),
-                                             msg));
+                                             jv_dump_string_for_errmsg(bad,errbuf,sizeof(errbuf)),
+                                             msg
+                                             ));
   jv_free(bad);
   return err;
 }
 
 static jv type_error2(jv bad1, jv bad2, const char* msg) {
-  jv err = jv_invalid_with_msg(jv_string_fmt("%s and %s %s",
+  char errbuf1[15],errbuf2[15];
+  jv err = jv_invalid_with_msg(jv_string_fmt("%s (%s) and %s (%s) %s",
                                              jv_kind_name(jv_get_kind(bad1)),
+                                             jv_dump_string_for_errmsg(bad1,errbuf1,sizeof(errbuf1)),
                                              jv_kind_name(jv_get_kind(bad2)),
-                                             msg));
+                                             jv_dump_string_for_errmsg(bad2,errbuf2,sizeof(errbuf2)),
+                                             msg
+                                             ));
   jv_free(bad1);
   jv_free(bad2);
   return err;

--- a/execute.c
+++ b/execute.c
@@ -636,7 +636,7 @@ jv jq_next(jq_state *jq) {
         }
       } else {
         assert(opcode == EACH || opcode == EACH_OPT);
-        f (opcode == EACH) {
+        if (opcode == EACH) {
           char errbuf[15];
           set_error(jq,
                     jv_invalid_with_msg(jv_string_fmt("Cannot iterate over %s (%s)",

--- a/execute.c
+++ b/execute.c
@@ -423,8 +423,11 @@ jv jq_next(jq_state *jq) {
         stack_push(jq, jv_object_set(objv, k, v));
         stack_push(jq, stktop);
       } else {
-        set_error(jq, jv_invalid_with_msg(jv_string_fmt("Cannot use %s as object key",
-                                                        jv_kind_name(jv_get_kind(k)))));
+        char errbuf[15];
+        set_error(jq, jv_invalid_with_msg(jv_string_fmt("Cannot use %s (%s) as object key",
+                                                        jv_kind_name(jv_get_kind(k)),
+                                                        jv_dump_string_for_errmsg(k,errbuf,sizeof(errbuf))
+                                                        )));
         jv_free(stktop);
         jv_free(v);
         jv_free(k);
@@ -633,10 +636,13 @@ jv jq_next(jq_state *jq) {
         }
       } else {
         assert(opcode == EACH || opcode == EACH_OPT);
-        if (opcode == EACH) {
+        f (opcode == EACH) {
+          char errbuf[15];
           set_error(jq,
-                    jv_invalid_with_msg(jv_string_fmt("Cannot iterate over %s",
-                                                      jv_kind_name(jv_get_kind(container)))));
+                    jv_invalid_with_msg(jv_string_fmt("Cannot iterate over %s (%s)",
+                                                      jv_kind_name(jv_get_kind(container)),
+                                                      jv_dump_string_for_errmsg(container,errbuf,sizeof(errbuf))
+                                                      )));
         }
         keep_going = 0;
       }

--- a/jv.h
+++ b/jv.h
@@ -171,6 +171,7 @@ void jv_dumpf(jv, FILE *f, int flags);
 void jv_dump(jv, int flags);
 void jv_show(jv, int flags);
 jv jv_dump_string(jv, int flags);
+char* jv_dump_string_for_errmsg(jv x, char* outbuf, size_t bufsize);
 
 enum {
   JV_PARSE_SEQ              = 1,

--- a/jv_print.c
+++ b/jv_print.c
@@ -313,3 +313,32 @@ jv jv_dump_string(jv x, int flags) {
   jvp_dtoa_context_free(&C);
   return s;
 }
+
+static inline void strncpyz(char *dest, const char*src, size_t n)
+{
+    strncpy(dest, src, n);
+    if (n>0)
+      dest[n-1] = 0;
+}
+
+//NOTE:
+//This function is special: it does NOT consume (decref) the input variable x.
+char* jv_dump_string_for_errmsg(jv x, char* outbuf, size_t bufsize) {
+  //NOTE:
+  // 'jv_dump_string' consumes (decref) the object -
+  // so make a copy (incref) before calling it.
+  jv s = jv_copy(x);
+  s = jv_dump_string(s,0);
+  const char* p = jv_string_value(s);
+  const size_t l = strlen(p);
+  strncpyz(outbuf,p,bufsize);
+  if ( (l>(bufsize-1)) && (bufsize>=4)) {
+    //The string representation of value 'X' is longer than the
+    //available buffer length - it's already truncated, indicate it with '...'
+    outbuf[bufsize-4]='.';
+    outbuf[bufsize-3]='.';
+    outbuf[bufsize-2]='.';
+  }
+  jv_free(s);
+  return outbuf;
+}


### PR DESCRIPTION
When reporting an error to the user, add information about the offending
object/value (possibly truncated).
The goal is to give a user some context regarding which input object
caused the runtime error.

* jv_print.c:
   strncpyz(): helper function
   jv_dump_string_for_errmsg() - return 'char*' of the object's string
                                 representation, truncate if needed.
* builtin.c:
   type_error(),type_error2(): use jv_dump_string_for_errmsg.
* execute.c:
   jq_next(): use jv_dump_string_for_errmsg.
* jv.h:
   declare jv_dump_string_for_errmsg.

Examples:

    $ echo '"hello"' | ./jq '-.'
    jq: error: string ("hello") cannot be negated

    $ echo '"very-long-string"' | ./jq '-.'
    jq: error: string ("very-long-...) cannot be negated

    $ echo '["1",2]' | ./jq '.|join("\t")'
    jq: error: string ("\t") and number (2) cannot be added

    $ echo '["1","2",{"a":{"b":{"c":33}}}]' | ./jq '.|join(",")'
    jq: error: string (",") and object ({"a":{"b":{...) cannot be added

    $ echo '{"a":{"b":{"c":33}}}' | ./jq '.a | @tsv'
    jq: error: object ({"b":{"c":33}}) cannot be csv-formatted, only array