### PR TITLE
string escape: skip NULs in output instead of asserting.

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -349,7 +349,8 @@ static jv escape_string(jv input, const char* escapings) {
   const char* cstart;
   int c = 0;
   while ((i = jvp_utf8_next((cstart = i), end, &c))) {
-    assert(c > 0);
+    if (c==0)
+      continue;
     if (c < 128 && lookup[c]) {
       ret = jv_string_append_str(ret, lookup[c]);
     } else {


### PR DESCRIPTION
While NULs are not expected in C/ASCII strings, they could be encoded
with unicode:

    $ echo '"a\u0000X"' | ./jq -r '[.]|@tsv' | od -tx1a
    jq: builtin.c:352: escape_string: Assertion `c > 0' failed.

As '\u0000' is a valid unicode symbol. The culprit is
`builtin.c:escape_string()` using `jvp_utf8_next` to iterate the string,
and it returns ascii 0 for '\u0000' - which is valid, but trigger the
assertion.

With this patch, encoded NULLs in the output are silently discarded when
escaping the string with '@tsv' or '@csv':

    $ echo '"a\u0000X"' | ./jq -r '[.]|@tsv' | od -tx1a
    0000000  61  58  0a
              a   X  nl

Note the encoded NULL is kept when not using @tsv/@csv:

    $ echo '"a\u0000X"' | ./jq '[.]'
    [
      "a\u0000X"
    ]