### PR TITLE
escape input NULLs as '\0' in raw/tsv/cvs output.

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -336,6 +336,7 @@ static jv escape_string(jv input, const char* escapings) {
   assert(jv_get_kind(input) == JV_KIND_STRING);
   const char* lookup[128] = {0};
   const char* p = escapings;
+  lookup[0] = "\\0";
   while (*p) {
     lookup[(int)*p] = p+1;
     p++;
@@ -349,7 +350,6 @@ static jv escape_string(jv input, const char* escapings) {
   const char* cstart;
   int c = 0;
   while ((i = jvp_utf8_next((cstart = i), end, &c))) {
-    assert(c > 0);
     if (c < 128 && lookup[c]) {
       ret = jv_string_append_str(ret, lookup[c]);
     } else {

--- a/jv.h
+++ b/jv.h
@@ -119,6 +119,7 @@ jv jv_string_append_str(jv a, const char* str);
 jv jv_string_split(jv j, jv sep);
 jv jv_string_explode(jv j);
 jv jv_string_implode(jv j);
+int jv_string_write_raw(jv v, FILE* stream);
 
 jv jv_object(void);
 jv jv_object_get(jv object, jv key);

--- a/main.c
+++ b/main.c
@@ -106,7 +106,7 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
   jv result;
   while (jv_is_valid(result = jq_next(jq))) {
     if ((options & RAW_OUTPUT) && jv_get_kind(result) == JV_KIND_STRING) {
-      fwrite(jv_string_value(result), 1, jv_string_length_bytes(jv_copy(result)), stdout);
+      jv_string_write_raw(result, stdout);
       ret = 0;
       jv_free(result);
     } else {


### PR DESCRIPTION
Input NULLs can be specified with "\u0000".

* builtin.c: escape_string(): always encode NUL (ascii 0x00) as '\0'.
  NOTE: this can't be specified in 'f_format()' in 'escapings' variable
  because the NUL itself will terminate the lookup loop in
  builtin.c:340.
* jv_print.c: new function 'jv_string_write_raw()' to print a JV_STRING
  to I/O stream (e.g. stderr/stdout) while escaping NUL to '\0'.
* jv.h: mention 'jv_string_write_raw()'.
* main.c: use 'jv_string_write_raw' in 'process()'.

Examples:

JSON (non-raw) output, same as before, NULs are encoded:

    $ echo '"a\u0000b"' | ./jq .
   "a\u0000b"

raw output without tsv/cvs, uses 'jv_string_write_raw':

    $ echo '"a\u0000b"' | ./jq -r .
    a\0b

raw output with tsv/cvs, uses 'escape_string':

    $ echo '"a\u0000b"' | ./jq -r '[.]|@tsv'
    a\0b