### PR TITLE
Fixes manual generation with psych

### DIFF
--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -87,7 +87,6 @@ task :binaries => ["output/download"] do
 end
 
 def load_manual
-  YAML::ENGINE.yamler = 'syck'
   YAML::load(File.open("content/3.manual/manual.yml"))
 end
 

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1,3 +1,4 @@
+---
 headline: jq Manual
 body: |
 
@@ -669,7 +670,7 @@ sections:
             input: '[[0,1], ["a","b","c"]]'
             output: ['[false, true]']
 
-      - title: `in`
+      - title: "`in`"
         body: |
           
           The builtin function `in` returns the input key is in the
@@ -1220,7 +1221,7 @@ sections:
             input: '"a,b, cd, efg, hijk"'
             output: ['12']
 
-      - title: `inside`
+      - title: "`inside`"
         body: |
 
           The filter `inside(b)` will produce true if the input is
@@ -1339,8 +1340,8 @@ sections:
 
         example:
           - program: 'ascii_upcase'
-            input: '"useful but not for é"'
-            output: '"USEFUL BUT NOT FOR é"'
+            input: '"useful but not for Ã©"'
+            output: '"USEFUL BUT NOT FOR Ã©"'
 
       - title: "`while(cond; update)`"
         body: |


### PR DESCRIPTION
When running `make` I ran into a couple of problems building the manual. While
I'm not entirely sure that this is the root cause, it appears to have been
related to the fact that ruby 2.0 dropped syck completely in favor of psych
(which was introduced in 1.9.2) for YAML processing. I'm currently using ruby
2.1.0p0.

I'm assuming that the fact that the YAML engine was explicitly set to syck in
the Rakefile was an attempt to work around some incompatibility between the two
libraries, so I looked into what would be necessary to get it to work with the
newer one. The changes to `manual.yml` ended up being pretty minor: I ran it
through `iconv` to convert some ISO-8859-1 characters to UTF-8 and added some
quotes in places (apparently you can't start a string value with '`').