### PR TITLE
Remove extension from links

### DIFF
--- a/docs/content/2.download/default.yml
+++ b/docs/content/2.download/default.yml
@@ -42,7 +42,7 @@ body:
 
       ### Solaris 11
 
-       * jq 1.4 executables for [64-bit](solaris11-64/jq.exe) or [32-bit](solaris11-32/jq.exe)
+       * jq 1.4 executables for [64-bit](solaris11-64/jq) or [32-bit](solaris11-32/jq)
 
       ### Windows
 


### PR DESCRIPTION
The downloads are available without an extension.

## Before
Links incorrectly have an extension

```
>curl -I http://stedolan.github.io/jq/download/solaris11-64/jq.exe
HTTP/1.1 404 Not Found
Server: GitHub.com
Content-Type: text/html; charset=utf-8
ETag: "5519ee21-247c"
Access-Control-Allow-Origin: *
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
Content-Length: 9340
Accept-Ranges: bytes
Date: Tue, 02 Jun 2015 18:59:47 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-jfk1021-JFK
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1433271587.604274,VS0,VE21
Vary: Accept-Encoding
```

## After
Extension is removed, HTTP 200 for each

```
> curl -I http://stedolan.github.io/jq/download/solaris11-64/jq
HTTP/1.1 200 OK
Server: GitHub.com
Content-Type: application/octet-stream
Last-Modified: Sat, 02 May 2015 22:43:34 GMT
Access-Control-Allow-Origin: *
Expires: Tue, 02 Jun 2015 19:09:53 GMT
Cache-Control: max-age=600
Content-Length: 419360
Accept-Ranges: bytes
Date: Tue, 02 Jun 2015 18:59:53 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-jfk1027-JFK
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1433271593.412672,VS0,VE40
Vary: Accept-Encoding

> curl -I http://stedolan.github.io/jq/download/solaris11-32/jq
HTTP/1.1 200 OK
Server: GitHub.com
Content-Type: application/octet-stream
Last-Modified: Sat, 02 May 2015 22:43:34 GMT
Access-Control-Allow-Origin: *
Expires: Tue, 02 Jun 2015 19:10:07 GMT
Cache-Control: max-age=600
Content-Length: 368304
Accept-Ranges: bytes
Date: Tue, 02 Jun 2015 19:00:07 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-iad2141-IAD
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1433271607.798947,VS0,VE8
Vary: Accept-Encoding
```