### PR TITLE
array and object destructuring (fix #533)

### DIFF
--- a/compile.h
+++ b/compile.h
@@ -41,14 +41,17 @@ block gen_subexp(block a);
 block gen_both(block a, block b);
 block gen_const_object(block expr);
 block gen_collect(block expr);
-block gen_reduce(const char* varname, block source, block init, block body);
-block gen_foreach(const char* varname, block source, block init, block update, block extract);
+block gen_reduce(block source, block matcher, block init, block body);
+block gen_foreach(block source, block matcher, block init, block update, block extract);
 block gen_definedor(block a, block b);
 block gen_condbranch(block iftrue, block iffalse);
 block gen_and(block a, block b);
 block gen_or(block a, block b);
 
 block gen_var_binding(block var, const char* name, block body);
+block gen_array_matcher(block left, block curr);
+block gen_object_matcher(block name, block curr);
+block gen_destructure(block var, block matcher, block body);
 
 block gen_cond(block cond, block iftrue, block iffalse);
 block gen_try_handler(block handler);

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -2147,6 +2147,11 @@ sections:
           with `$x` set to that value.  Thus `as` functions as something of a
           foreach loop.
 
+          Multiple variables may be declared using a single `as` expression by
+          providing a pattern that matches the structure of the input:
+
+              . as {realnames: $names, posts: [$first, $second]} | ...
+
           Variables are scoped over the rest of the expression that defines
           them, so
 
@@ -2171,6 +2176,9 @@ sections:
           - program: '. as $i|[(.*2|. as $i| $i), $i]'
             input: '5'
             output: ['[10,5]']
+          - program: '. as [$a, $b, {c: $c}] | $a + $b + $c'
+            input: '[2, 3, {c: 4, d: 5}]'
+            output: ['9']
 
       - title: 'Defining Functions'
         body: |

--- a/tests/all.test
+++ b/tests/all.test
@@ -271,6 +271,14 @@ jq: error: *label-foo/0 is not defined at <top-level>, line 1:
 null
 [0,1,2,3,4]
 
+[foreach .[] as [$i, $j] (0; . + $i - $j)]
+[[2,1], [5,3], [6,4]]
+[1,3,5]
+
+[foreach .[] as {a:$a} (0; . + $a; -.)]
+[{"a":1}, {"b":2}, {"a":3, "b":4}]
+[-1, -1, -4]
+
 [limit(3; .[])]
 [11,22,33,44,55,66,77,88,99]
 [11,22,33]
@@ -372,6 +380,37 @@ null
 1 as $x | [$x,$x,$x as $x | $x]
 null
 [1,1,1]
+
+[1, {c:3, d:4}] as [$a, {c:$b, b:$c}] | $a, $b, $c
+null
+1
+3
+null
+
+. as {as: $kw, "str": $str, ("e"+"x"+"p"): $exp} | [$kw, $str, $exp]
+{"as": 1, "str": 2, "exp": 3}
+[1, 2, 3]
+
+.[] as [$a, $b] | [$b, $a]
+[[1], [1, 2, 3]]
+[null, 1]
+[2, 1]
+
+. as $i | . as [$i] | $i
+[0]
+0
+
+. as [$i] | . as $i | $i
+[0]
+[0]
+
+%%FAIL
+. as [] | null
+jq: error: syntax error, unexpected ']', expecting '$' or '[' or '{' (Unix shell quoting issues?) at <top-level>, line 1:
+
+%%FAIL
+. as {} | null
+jq: error: syntax error, unexpected '}' (Unix shell quoting issues?) at <top-level>, line 1:
 
 # [.,(.[] | {x:.},.),.,.[]]
 
@@ -609,6 +648,14 @@ def fac: if . == 1 then 1 else . * (. - 1 | fac) end; [.[] | fac]
 reduce .[] as $x (0; . + $x)
 [1,2,4]
 7
+
+reduce .[] as [$i, {j:$j}] (0; . + $i - $j)
+[[2,{"j":1}], [5,{"j":3}], [6,{"j":4}]]
+5
+
+reduce [[1,2,10], [3,4,10]][] as [$i,$j] (0; . + $i * $j)
+null
+14
 
 . as $dot|any($dot[];not)
 [1,2,3,4,true,false,1,2,3,4,5]


### PR DESCRIPTION
`. as [$i, $j, $k] | ...`
`. as {a: $i, b: $j} | ...`
`. as [[[$i]], {a: $j}] | ...`