### PR TITLE
Proposal: combinations/0 and combinations/1

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -1424,19 +1424,16 @@ static const char* const jq_builtins[] = {
   "def first: .[0];",
   "def last: .[-1];",
   "def nth($n): .[$n];",
-  "def product:"
-  "    if any(length == 0) then [] else"
-  "        reverse |"
-  "        reduce .[] as $i ("
-  "            [];"
-  "            [{x: $i[], xs: (.[] // null)}]"
-  "        ) |"
-  "        map([recurse(.xs?).x?])"
+  "def combinations:"
+  "    if length == 0 or any(length == 0) then empty else"
+  "        .[0][] as $x |"
+  "        (.[1:] | combinations) // [] as $y |"
+  "        [$x] + $y"
   "    end;",
-  "def product(n):"
+  "def combinations(n):"
   "    . as $dot |"
   "    [range(n) | $dot] |"
-  "    product;",
+  "    combinations;",
   // # transpose a possibly jagged matrix, quickly;
   // # rows are padded with nulls so the result is always rectangular.
   "def transpose:"

--- a/builtin.c
+++ b/builtin.c
@@ -1425,12 +1425,14 @@ static const char* const jq_builtins[] = {
   "def last: .[-1];",
   "def nth($n): .[$n];",
   "def product:"
-  "    reverse |"
-  "    reduce .[] as $i ("
-  "         [];"
-  "         [{x: $i[], xs: (.[] // null)}]"
-  "    ) |"
-  "    map([recurse(.xs?).x?]);",
+  "    if any(length == 0) then [] else"
+  "        reverse |"
+  "        reduce .[] as $i ("
+  "            [];"
+  "            [{x: $i[], xs: (.[] // null)}]"
+  "        ) |"
+  "        map([recurse(.xs?).x?])"
+  "    end;",
   "def product(n):"
   "    . as $dot |"
   "    [range(n) | $dot] |"

--- a/builtin.c
+++ b/builtin.c
@@ -1426,11 +1426,9 @@ static const char* const jq_builtins[] = {
   "def nth($n): .[$n];",
   "def combinations:"
   "    if length == 0 then [] else"
-  "        if any(length == 0) then empty else"
-  "            .[0][] as $x"
-  "              | (.[1:] | combinations) as $y"
-  "              | [$x] + $y"
-  "        end"
+  "        .[0][] as $x"
+  "          | (.[1:] | combinations) as $y"
+  "          | [$x] + $y"
   "    end;",
   "def combinations(n):"
   "    . as $dot"

--- a/builtin.c
+++ b/builtin.c
@@ -1425,10 +1425,12 @@ static const char* const jq_builtins[] = {
   "def last: .[-1];",
   "def nth($n): .[$n];",
   "def combinations:"
-  "    if length == 0 or any(length == 0) then [] else"
-  "        .[0][] as $x"
-  "          | (.[1:] | combinations) as $y"
-  "          | [$x] + $y"
+  "    if length == 0 then [] else"
+  "        if any(length == 0) then empty else"
+  "            .[0][] as $x"
+  "              | (.[1:] | combinations) as $y"
+  "              | [$x] + $y"
+  "        end"
   "    end;",
   "def combinations(n):"
   "    . as $dot"

--- a/builtin.c
+++ b/builtin.c
@@ -1425,15 +1425,15 @@ static const char* const jq_builtins[] = {
   "def last: .[-1];",
   "def nth($n): .[$n];",
   "def combinations:"
-  "    if length == 0 or any(length == 0) then empty else"
-  "        .[0][] as $x |"
-  "        (.[1:] | combinations) // [] as $y |"
-  "        [$x] + $y"
+  "    if length == 0 or any(length == 0) then [] else"
+  "        .[0][] as $x"
+  "          | (.[1:] | combinations) as $y"
+  "          | [$x] + $y"
   "    end;",
   "def combinations(n):"
-  "    . as $dot |"
-  "    [range(n) | $dot] |"
-  "    combinations;",
+  "    . as $dot"
+  "      | [range(n) | $dot]"
+  "      | combinations;",
   // # transpose a possibly jagged matrix, quickly;
   // # rows are padded with nulls so the result is always rectangular.
   "def transpose:"

--- a/builtin.c
+++ b/builtin.c
@@ -1424,7 +1424,18 @@ static const char* const jq_builtins[] = {
   "def first: .[0];",
   "def last: .[-1];",
   "def nth($n): .[$n];",
-  // # transpose a possibly jagged matrix, quickly; 
+  "def product:"
+  "    reverse |"
+  "    reduce .[] as $i ("
+  "         [];"
+  "         [{x: $i[], xs: (.[] // null)}]"
+  "    ) |"
+  "    map([recurse(.xs?).x?]);",
+  "def product(n):"
+  "    . as $dot |"
+  "    [range(n) | $dot] |"
+  "    product;",
+  // # transpose a possibly jagged matrix, quickly;
   // # rows are padded with nulls so the result is always rectangular.
   "def transpose:"
   "  if . == [] then []"

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1279,6 +1279,21 @@ sections:
             input: '["foobar", "barfoo"]'
             output: ['[false, true]']
 
+      - title: "`combinations`, `combinations(n)`"
+        body: |
+
+          Outputs all combinations of the elements of the arrays in the
+          input array. If given an argument `n`, it outputs all combinations
+          of `n` repetitions of the input array.
+
+        examples:
+          - program: 'combinations'
+            input: '[[1,2], [3, 4]]'
+            output: ['[1, 3]', '[1, 4]', '[2, 3]', '[2, 4]']
+          - program: 'combinations(2)'
+            input: '[0, 1]'
+            output: ['[0, 0]', '[0, 1]', '[1, 0]', '[1, 1]']
+
       - title: "`ltrimstr(str)`"
         body: |
 


### PR DESCRIPTION
This is an implementation of Python's [`itertools.product()`](https://docs.python.org/2/library/itertools.html#itertools.product) function.

The filter `product/0` takes an array of arrays as input and generates the product combination of those arrays. The filter `product/1` takes an array as input and a number `n` as argument and generates the product combination of `n` copies of the same array. Some samples:

```
jq -n '[["a", "b"], ["c", "d"]] | product | map(join(""))'
[
  "ac",
  "ad",
  "bc",
  "bd"
]
```

```
jq -n '["0", "1"] | product(2) | map(join(""))'
[
  "00",
  "01",
  "10",
  "11"
]
```

The documentation is not there, so it is not ready to merge; but if there's interest on having this merged, I will work on the documentation.