### PR TITLE
Add alloca() discovery

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -1,10 +1,22 @@
 #define _BSD_SOURCE
 #define _XOPEN_SOURCE
 #include <sys/time.h>
-#ifdef WIN32
-  #include <malloc.h>
-#else
-  #include <alloca.h>
+#include <stdlib.h>
+#include <stddef.h>
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h>
+#elif !defined alloca
+# ifdef __GNUC__
+#  define alloca __builtin_alloca
+# elif defined _MSC_VER
+#  include <malloc.h>
+#  define alloca _alloca
+# elif !defined HAVE_ALLOCA
+#  ifdef  __cplusplus
+extern "C"
+#  endif
+void *alloca (size_t);
+# endif
 #endif
 #include <assert.h>
 #include <ctype.h>
@@ -13,7 +25,6 @@
 #ifdef HAVE_ONIGURUMA
 #include <oniguruma.h>
 #endif
-#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include "builtin.h"

--- a/configure.ac
+++ b/configure.ac
@@ -172,5 +172,6 @@ AC_SUBST([BUNDLER], ["$bundle_cmd"])
 AC_CONFIG_MACRO_DIR([config/m4])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
+AC_FUNC_ALLOCA
 
 

--- a/util.c
+++ b/util.c
@@ -10,8 +10,24 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <string.h>
-#include <stdlib.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <stddef.h>
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h>
+#elif !defined alloca
+# ifdef __GNUC__
+#  define alloca __builtin_alloca
+# elif defined _MSC_VER
+#  include <malloc.h>
+#  define alloca _alloca
+# elif !defined HAVE_ALLOCA
+#  ifdef  __cplusplus
+extern "C"
+#  endif
+void *alloca (size_t);
+# endif
+#endif
 #ifndef WIN32
 #include <pwd.h>
 #endif


### PR DESCRIPTION
The build failed on FreeBSD as there is no alloca.h.  This patch is lifted from the autoconf documentation.

I've only tested this on FreeBSD 10.1-RELEASE-p6, Ubuntu 12.04.5 LTS, and Darwin 14.0.0.