### PR TITLE
fix errors flagged by clang static analyzer

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -671,8 +671,7 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
     return jv_invalid_with_msg(jv_string_concat(jv_string("Regex failure: "),
           jv_string((char*)ebuf)));
   }
-  if (!test)
-    result = jv_array();
+  result = test ? jv_false() : jv_array();
   const char *input_string = jv_string_value(input);
   const UChar* start = (const UChar*)jv_string_value(input);
   const unsigned long length = jv_string_length_bytes(jv_copy(input));
@@ -760,8 +759,6 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
       start = (const UChar*)(input_string+region->end[0]);
       onig_region_free(region,0);
     } else if (onigret == ONIG_MISMATCH) {
-      if (test)
-        result = jv_false();
       break;
     } else { /* Error */
       UChar ebuf[ONIG_MAX_ERROR_MESSAGE_LEN];

--- a/compile.c
+++ b/compile.c
@@ -943,7 +943,7 @@ block gen_cbinding(const struct cfunction* cfunctions, int ncfunctions, block co
 
 static uint16_t nesting_level(struct bytecode* bc, inst* target) {
   uint16_t level = 0;
-  assert(bc && target->compiled);
+  assert(bc && target && target->compiled);
   while (bc && target->compiled != bc) {
     level++;
     bc = bc->parent;

--- a/jq_test.c
+++ b/jq_test.c
@@ -87,14 +87,15 @@ static void run_jq_tests(jv lib_dirs, FILE *testdata) {
 
     if (must_fail) {
       jq_set_error_cb(jq, NULL, NULL);
-      must_fail = 0;
-      check_msg = 0;
       if (!fgets(buf, sizeof(buf), testdata)) { invalid++; break; }
       lineno++;
       if (buf[strlen(buf)-1] == '\n') buf[strlen(buf)-1] = 0;
       if (compiled) {
         printf("*** Test program compiled that should not have at line %u: %s\n", lineno, prog);
-        invalid++; continue;
+        must_fail = 0;
+        check_msg = 0;
+        invalid++;
+        continue;
       }
       if (check_msg && strcmp(buf, err_msg.buf) != 0) {
         printf("*** Erroneous test program failed with wrong message (%s) at line %u: %s\n", err_msg.buf, lineno, prog);
@@ -102,6 +103,8 @@ static void run_jq_tests(jv lib_dirs, FILE *testdata) {
       } else {
         passed++;
       }
+      must_fail = 0;
+      check_msg = 0;
       continue;
     }
 

--- a/jv.c
+++ b/jv.c
@@ -473,6 +473,7 @@ static jv jvp_string_copy_replace_bad(const char* data, uint32_t length) {
 
 /* Assumes valid UTF8 */
 static jv jvp_string_new(const char* data, uint32_t length) {
+  assert(data);
   jvp_string* s = jvp_string_alloc(length);
   s->length_hashed = length << 1;
   memcpy(s->data, data, length);

--- a/jv_alloc.c
+++ b/jv_alloc.c
@@ -169,8 +169,11 @@ void* jv_mem_realloc(void* p, size_t sz) {
 #ifndef NDEBUG
 volatile char jv_mem_uninitialised;
 __attribute__((constructor)) void jv_mem_uninit_setup(){
+  // ignore warning that this reads uninitialized memory - that's the point!
+#ifndef __clang_analyzer__
   char* p = malloc(1);
   jv_mem_uninitialised = *p;
   free(p);
+#endif
 }
 #endif

--- a/jv_file.c
+++ b/jv_file.c
@@ -33,7 +33,6 @@ jv jv_load_file(const char* filename, int raw) {
       if (jv_invalid_has_msg(jv_copy(value))) {
         jv_free(data);
         data = value;
-        value = jv_invalid();
         break;
       }
     }


### PR DESCRIPTION
builtin.c: bug - free of uninitialized jv
compile.c: missing assertion
jq_test.c: buggy logic / unreachable code
jv.c: missing assertion
jv_alloc.c: false positive - intentional read of uninitialized memory
jv_file.c: dead code