### PR TITLE
Support non ASCII content on Windows

### DIFF
--- a/jv_print.c
+++ b/jv_print.c
@@ -3,6 +3,9 @@
 #include <float.h>
 #include <string.h>
 #include <assert.h>
+#ifdef WIN32
+#include <windows.h>
+#endif
 
 #include "jv_dtoa.h"
 #include "jv_unicode.h"
@@ -25,7 +28,12 @@ static void put_buf(const char* s, int len, FILE* fout, jv* strout) {
   if (strout) {
     *strout = jv_string_append_buf(*strout, s, len);
   } else {
+#ifdef WIN32
+    DWORD written;
+    WriteFile(fout, s, len, &written, 0);
+#else
     fwrite(s, 1, len, fout);
+#endif
   }
 }
 
@@ -297,7 +305,11 @@ void jv_dumpf(jv x, FILE *f, int flags) {
 }
 
 void jv_dump(jv x, int flags) {
+#ifdef WIN32
+  jv_dumpf(x, GetStdHandle(STD_OUTPUT_HANDLE), flags);
+#else
   jv_dumpf(x, stdout, flags);
+#endif
 }
 
 /* This one is nice for use in debuggers */


### PR DESCRIPTION
With #811 being resolved, JQ now supports filenames with non ASCII characters on
Windows:

~~~json
$ jq . Ω.json
{
  "alpha": "bravo"
}
~~~

However it appears that no Windows version of JQ supports non ASCII content:

~~~json
$ cat alpha.json
{"alpha":"Ω"}

$ jq . alpha.json
{
  "alpha": "��"
}
~~~

Note this is with all Windows versions of JQ, including master:

~~~
$ jq --version
jq-1.5rc1-114-g7811ef1-dirty
~~~

even with correct code page:

~~~
$ chcp.com
Active code page: 65001
~~~

and the file is correctly encoded as UTF-8:

~~~
$ od -tx1c alpha.json
0000000  7b  22  61  6c  70  68  61  22  3a  22  ce  a9  22  7d  0a
          {   "   a   l   p   h   a   "   :   " 316 251   "   }  \n
~~~