### PR TITLE
Enable code coverage / coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,15 @@ sudo: false
 
 language: c
 
+compiler:
+    - gcc
+    - clang
+
+matrix:
+    include:
+        - compiler: gcc
+          env: COVERAGE="--disable-valgrind --enable-gcov"
+
 addons:
     apt:
         packages:
@@ -23,13 +32,14 @@ install:
     - ar p libonig2_5.9.6-1_amd64.deb data.tar.xz | tar xJ
     - mv usr/lib/x86_64-linux-gnu/libonig.so* usr/lib
 
-    - valgrind --version
+    - if [ -n "$COVERAGE" ]; then pip install --user cpp-coveralls; fi
 
 before_script:
     - autoreconf -i
     - ./configure
         --with-oniguruma=usr
         YACC="usr/bin/bison -y"
+        $COVERAGE
 
 script:
     - make -j4
@@ -37,13 +47,13 @@ script:
         BISON_PKGDATADIR=$(pwd)/usr/share/bison
     - make check -j4
 
+after_script:
+    - rm -rf .libs # don't care about coverage for libjq
+    - if [ -n "$COVERAGE" ]; then coveralls --gcov-options '\-lp'; fi
+
 after_failure:
     - cat test-suite.log
     - cat tests/*.log
-
-compiler:
-    - gcc
-    - clang
 
 notifications:
     email: false

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,12 @@ else
 NO_VALGRIND = 1
 endif
 
+### Code coverage with gcov
+
+if ENABLE_GCOV
+AM_CFLAGS += --coverage --no-inline
+endif
+
 ### Error injection for testing
 
 if ENABLE_ERROR_INJECTION
@@ -176,11 +182,15 @@ dist-clean-local:
 # Not sure why this doesn't get cleaned up automatically, guess
 # automake used to man pages which are hand coded?
 # 'make clean' doesn't delete the manpage if it can't be rebuilt
-.PHONY: clean-local-docs
 clean-local-docs:
 if ENABLE_DOCS
 	rm -f jq.1
 endif 
 
-clean-local: clean-local-docs
+clean-local-gcov:
+	rm -f *.gcno *.gcda *.gcov
+
+clean-local: clean-local-docs clean-local-gcov
 	rm -f version.h .remake-version-h
+
+.PHONY: clean-local-docs clean-local-gcov

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,14 @@ libjq_la_LDFLAGS = -export-symbols-regex '^j[qv]_' -version-info 1:4:0
 
 include_HEADERS = jv.h jq.h
 
+### Running tests under Valgrind
+
+if ENABLE_VALGRIND
+NO_VALGRIND =
+else
+NO_VALGRIND = 1
+endif
+
 ### Error injection for testing
 
 if ENABLE_ERROR_INJECTION
@@ -80,6 +88,7 @@ endif
 ### Tests (make check)
 
 TESTS = tests/mantest tests/jqtest tests/onigtest tests/shtest
+TESTS_ENVIRONMENT = NO_VALGRIND=$(NO_VALGRIND)
 
 
 ### Building the manpage

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,10 @@ dnl fix leaks.
 AC_ARG_ENABLE([valgrind],
    AC_HELP_STRING([--disable-valgrind], [do not run tests under Valgrind]))
 
+dnl Code coverage
+AC_ARG_ENABLE([gcov],
+   AC_HELP_STRING([--enable-gcov], [enable gcov code coverage tool]))
+
 dnl Don't attempt to build docs if there's no Ruby lying around
 AC_ARG_ENABLE([docs],
    AC_HELP_STRING([--disable-docs], [don't build docs]))
@@ -126,6 +130,7 @@ EOF
 ])
 
 AM_CONDITIONAL([ENABLE_VALGRIND], [test "x$enable_valgrind" != xno])
+AM_CONDITIONAL([ENABLE_GCOV], [test "x$enable_gcov" = xyes])
 AM_CONDITIONAL([ENABLE_DOCS], [test "x$enable_docs" != xno])
 AM_CONDITIONAL([ENABLE_ERROR_INJECTION], [test "x$enable_error_injection" = xyes])
 AM_CONDITIONAL([ENABLE_ALL_STATIC], [test "x$enable_all_static" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,12 @@ AC_CHECK_FUNCS(memmem)
 AC_CHECK_FUNCS(mkstemp)
 
 
+dnl Running tests with Valgrind is slow. It is faster to iterate on
+dnl code without Valgrind until tests pass, then enable Valgrind and
+dnl fix leaks.
+AC_ARG_ENABLE([valgrind],
+   AC_HELP_STRING([--disable-valgrind], [do not run tests under Valgrind]))
+
 dnl Don't attempt to build docs if there's no Ruby lying around
 AC_ARG_ENABLE([docs],
    AC_HELP_STRING([--disable-docs], [don't build docs]))
@@ -119,6 +125,7 @@ EOF
    fi
 ])
 
+AM_CONDITIONAL([ENABLE_VALGRIND], [test "x$enable_valgrind" != xno])
 AM_CONDITIONAL([ENABLE_DOCS], [test "x$enable_docs" != xno])
 AM_CONDITIONAL([ENABLE_ERROR_INJECTION], [test "x$enable_error_injection" = xyes])
 AM_CONDITIONAL([ENABLE_ALL_STATIC], [test "x$enable_all_static" = xyes])

--- a/tests/setup
+++ b/tests/setup
@@ -8,7 +8,7 @@ JQTESTDIR=$(cd "$(dirname "$0")" && pwd)
 JQBASEDIR=$JQTESTDIR/..
 JQ=$JQBASEDIR/jq
 
-if which valgrind > /dev/null; then
+if [ -z "${NO_VALGRIND-}" ] && which valgrind > /dev/null; then
     VALGRIND="valgrind --error-exitcode=1 --leak-check=full \
                        --suppressions=$JQTESTDIR/onig.supp"
     Q=-q


### PR DESCRIPTION
Here is the result of this branch: https://coveralls.io/builds/2919770

Here is the same build on Travis: https://travis-ci.org/dtolnay/jq/jobs/68623801

The coverage build runs in parallel to the existing gcc and clang valgrind builds: https://travis-ci.org/dtolnay/jq/builds/68623798

There are two commits included in this PR. The first adds --disable-valgrind, the second adds --enable-gcov, and the coveralls build uses both.