### PR TITLE
gcov exclusions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,11 @@ script:
     - make check -j4
 
 after_script:
-    - rm -rf .libs # don't care about coverage for libjq
-    - if [ -n "$COVERAGE" ]; then coveralls --gcov-options '\-lp'; fi
+    - |
+        if [ -n "$COVERAGE" ]; then
+            rm -rf .libs usr # don't care about coverage for libjq, bison, libonig
+            coveralls -e lexer.c -e parser.c -e jv_dtoa.c --gcov-options '\-lp'
+        fi
 
 after_failure:
     - cat test-suite.log


### PR DESCRIPTION
86.6% after excluding lexer.c, parser.c, jv_dtoa.c

https://coveralls.io/builds/2920453 ![86.6%](https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_86.svg)