### PR TITLE
Make jq.h usable from C++

### DIFF
--- a/jq.h
+++ b/jq.h
@@ -43,15 +43,15 @@ jv jq_get_attr(jq_state *, jv);
  * whereas jv string values must be in UTF-8.  This way the caller
  * doesn't have to perform any codeset conversions.
  */
-typedef struct jq_util_input_state *jq_util_input_state;
+typedef struct jq_util_input_state jq_util_input_state;
 typedef void (*jq_util_msg_cb)(void *, const char *);
 
-jq_util_input_state jq_util_input_init(jq_util_msg_cb, void *);
-void jq_util_input_set_parser(jq_util_input_state, jv_parser *, int);
-void jq_util_input_free(jq_util_input_state *);
-void jq_util_input_add_input(jq_util_input_state, const char *);
-int jq_util_input_errors(jq_util_input_state);
-jv jq_util_input_next_input(jq_util_input_state);
+jq_util_input_state *jq_util_input_init(jq_util_msg_cb, void *);
+void jq_util_input_set_parser(jq_util_input_state *, jv_parser *, int);
+void jq_util_input_free(jq_util_input_state **);
+void jq_util_input_add_input(jq_util_input_state *, const char *);
+int jq_util_input_errors(jq_util_input_state *);
+jv jq_util_input_next_input(jq_util_input_state *);
 jv jq_util_input_next_input_cb(jq_state *, void *);
 jv jq_util_input_get_position(jq_state*);
 jv jq_util_input_get_current_filename(jq_state*);

--- a/main.c
+++ b/main.c
@@ -207,7 +207,7 @@ int main(int argc, char* argv[]) {
   int dumpopts = JV_PRINT_INDENT_FLAGS(2);
   const char* program = 0;
 
-  jq_util_input_state input_state = jq_util_input_init(NULL, NULL); // XXX add err_cb
+  jq_util_input_state *input_state = jq_util_input_init(NULL, NULL); // XXX add err_cb
 
   int further_args_are_files = 0;
   int jq_flags = 0;


### PR DESCRIPTION
Previously, with clang++:
jq.h:46:37: error: typedef redefinition with different
      types ('struct jq_util_input_state *' vs 'jq_util_input_state')

With g++:
jq.h:46:37: error: conflicting declaration
      ‘typedef struct jq_util_input_state* jq_util_input_state’

This typedef was added to libjq by commit 0d41447 which was
after the 1.4 release, so although it is a public API, this
is not a backcompat break because it has never been in a
release.

Specifying the "*" at all uses of jq_util_input_state is
slightly tedious, but jq_state already works that way, so at
least it will be consistent.