### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,50 @@
-FROM debian:wheezy
-
-# get dependencies
-
-RUN apt-get update
-
-RUN apt-get install -y build-essential
-RUN apt-get install -y autoconf
-RUN apt-get install -y libonig2
-RUN apt-get install -y libtool
-RUN apt-get install -y git
-RUN apt-get install -y valgrind
-RUN apt-get install -y bison
-RUN apt-get install -y flex
-RUN apt-get install -y ruby1.9.3
-
-RUN gem install bundler
-
-# get docs dependencies
-
-COPY ./docs/Gemfile /app/docs/Gemfile
-COPY ./docs/Gemfile.lock /app/docs/Gemfile.lock
-
-WORKDIR /app/docs
-
-RUN bundle install
-
-# copy files
-
-WORKDIR /app
+FROM debian:8
 
 COPY . /app
 
-# build
+# get dependencies, build, and remove anything we don't need for running jq.
+# valgrind seems to have trouble with pthreads TLS so it's off.
 
-RUN autoreconf -i
-RUN ./configure
-RUN make -j8
-RUN make check
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+	autoconf \
+	libtool \
+	git \
+	bison \
+	flex \
+	ruby \
+	wget \
+	ruby-dev && \
+    wget http://www.geocities.jp/kosako3/oniguruma/archive/onig-5.9.6.tar.gz && \
+    sha512sum onig-5.9.6.tar.gz | grep 4a181ea6f0e1a018bbaf6c87e666dfffd1ef4b8f5dcead07fa0b6564a76174e7e01854173924668433ae74c455dbced6a0e1b43e9066f0499b4a57e855e1a2b2 && \
+    tar zxvf onig-5.9.6.tar.gz && \
+    (cd onig-5.9.6 && \
+        ./configure --prefix=/usr/local && \
+        make && \
+	make install ) && \
+    gem install bundler && \
+    (cd /app/docs && bundle install) && \
+    (cd /app && \
+        autoreconf -i && \
+        ./configure --disable-valgrind --enable-all-static --prefix=/usr/local && \
+	make -j8 && \
+	make check && \
+	make install && \
+	make distclean ) && \
+    (cd onig-5.9.6 && \
+        make uninstall ) && \
+    apt-get purge -y \
+        build-essential \
+	autoconf \
+	libtool \
+	bison \
+	git \
+	flex \
+	ruby \
+	ruby-dev && \
+    apt-get autoremove -y && \
+    rm -rf onig-5.9.6 && \
+    rm -rf /var/lib/apt/lists/* /var/lib/gems
+
+ENTRYPOINT ["/usr/local/bin/jq"]


### PR DESCRIPTION
* Remove excess layer creation
  This is an antipattern in Docker.
* Remove build tools once build is complete
  Leaving them around is not necessary and expands the image size many times
* Make check works with libonig installed
* Compiles statically (needs libonig to be built rather than installed)
* Valgrind doesn't work with the use of pthread TLS in jq so it's disabled -- this
  might be a FIXME situation; I'm not familiar enough with valgrind to
  say whether this is expected
* Make entrypoint be the jq binary so that the image can also be used
  to run jq in environments where you don't want to or can't install
  jq (such as CoreOS).

See https://registry.hub.docker.com/u/jamesandariese/jq/ for a ready to use docker image with jq.

One can either get the static bin out of the docker container as suggested in the original Dockerfile pull request or one can use jq directly with docker like so:

    echo '"hi"' | docker run -i jamesandariese/jq .
    "hi"
