### PR TITLE
Fixing missing D in LIBM_DDD_NO macro name

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -1233,7 +1233,7 @@ static jv f_current_line(jq_state *jq) {
 
 #define LIBM_DDD(name) \
   {(cfunction_ptr)f_ ## name, "_" #name, 3},
-#define LIBM_DD_NO(name)
+#define LIBM_DDD_NO(name)
    
 static const struct cfunction function_list[] = {
 #include "libm.h"


### PR DESCRIPTION
Had problems compiling because this macro looked to be misnamed.  Added another D and it seemed to be happy.  Didn't look too much further into (hey, it compiled :) it so it might warrant further investigation.