### PR TITLE
fix references to --color-output

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -148,7 +148,7 @@ sections:
 
         Use the given number of spaces (no more than 8) for indentation.
 
-      * `--colour-output` / `-C` and `--monochrome-output` / `-M`:
+      * `--color-output` / `-C` and `--monochrome-output` / `-M`:
 
         By default, jq outputs colored JSON if writing to a
         terminal. You can force it to produce color even if writing to

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -73,7 +73,7 @@ Don\'t read any input at all! Instead, the filter is run once using \fBnull\fR a
 By default, jq pretty\-prints JSON output\. Using this option will result in more compact output by instead putting each JSON object on a single line\.
 .
 .IP "\(bu" 4
-\fB\-\-colour\-output\fR / \fB\-C\fR and \fB\-\-monochrome\-output\fR / \fB\-M\fR:
+\fB\-\-color\-output\fR / \fB\-C\fR and \fB\-\-monochrome\-output\fR / \fB\-M\fR:
 .
 .IP
 By default, jq outputs colored JSON if writing to a terminal\. You can force it to produce color even if writing to a pipe or a file using \fB\-C\fR, and disable color with \fB\-M\fR\.


### PR DESCRIPTION
The manpage and manual specify `colour`, but main.c uses `color`.

``` c
      if (isoption(argv[i], 'C', "color-output", &short_opts)) {
```