### PR TITLE
Error on bytecodes longer than 0xFFFF (fix #269)

### DIFF
--- a/compile.h
+++ b/compile.h
@@ -75,7 +75,7 @@ block block_drop_unreferenced(block body);
 
 jv block_take_imports(block* body);
 
-int block_compile(block, struct bytecode**);
+int block_compile(block, struct bytecode**, struct locfile*);
 
 void block_free(block);
 

--- a/execute.c
+++ b/execute.c
@@ -1088,7 +1088,7 @@ int jq_compile_args(jq_state *jq, const char* str, jv args) {
 
     nerrors = builtins_bind(jq, &program);
     if (nerrors == 0) {
-      nerrors = block_compile(program, &jq->bc);
+      nerrors = block_compile(program, &jq->bc, locations);
     }
   }
   if (nerrors)


### PR DESCRIPTION
This lets us use uint16_t for the program counter. JVM
languages have the same limit on method size so it is a
reasonable limit.