### PR TITLE
Avoid passing '/bin/bash' as default argument to docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,4 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /var/lib/gems
 
 ENTRYPOINT ["/usr/local/bin/jq"]
+CMD []


### PR DESCRIPTION
Previously:

```
$ docker run dbdc663dabc8
jq: error: syntax error, unexpected '/', expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
/bin/bash
jq: 1 compile error
$ docker run --entrypoint /bin/echo dbdc663dabc8
/bin/bash
```

Now:

```
$ docker run e36393e8c15e
jq - commandline JSON processor [version 1.5rc2-77-g9a3fe9e]
Usage: /usr/local/bin/jq [options] <jq filter> [file...]

	jq is a tool for processing JSON inputs, applying the
...
```