### PR TITLE
Segmentation fault on Windows with long paths

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -47,7 +47,7 @@ void *alloca (size_t);
 
 #ifdef WIN32
 FILE *fopen(const char *fname, const char *mode) {
-  size_t sz = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
+  size_t sz = sizeof(wchar_t) * MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
   wchar_t *wfname = alloca(sz);
   MultiByteToWideChar(CP_UTF8, 0, fname, -1, wfname, sz);
 


### PR DESCRIPTION
Consider this script:

~~~sh
#!/bin/sh
set 6789012345678901234567{,8,89}.json
echo '{"delta": 2}' | tee $*
jq . $1
jq . $2
jq . $3
~~~

With JQ master, here is the result:

~~~
{
  "delta": 2
}

Segmentation fault
~~~

So path of 27 characters or less is good, 28 gives no output, and 29 or more is
segfault. Git bisect reveals 7811ef1e1746f0963deb960af2c9623fb53c24a5 to be the
culprit:

~~~
7811ef1e1746f0963deb960af2c9623fb53c24a5 is the first bad commit
commit 7811ef1e1746f0963deb960af2c9623fb53c24a5
Author: Nicolas Williams <nico@cryptonector.com>
Date:   Fri Jun 19 17:10:45 2015 -0500
Fix #811: use CommandLineToArgvW() and _wfopen()
~~~