### PR TITLE
docs: jq 1.5 is now available in Debian unstable

### DIFF
--- a/docs/content/2.download/default.yml
+++ b/docs/content/2.download/default.yml
@@ -16,7 +16,7 @@ body:
 
       ### Linux
 
-       * jq 1.4 is in the official [Debian](https://packages.debian.org/jq) and
+       * jq 1.5 is in the official [Debian](https://packages.debian.org/jq) and
          [Ubuntu](http://packages.ubuntu.com/jq) repositories. Install using
          `sudo apt-get install jq`.
 


### PR DESCRIPTION
I have updated the Debian packaging to the 1.5 upstream release. You can find a changelog of the packaging [here](http://packages.qa.debian.org/j/jq/news/20151012T071912Z.html).

The new version of jq in Debian does not build libjq separately but bakes it into the binary; however, libonig2 is linked dynamically.

You can check the list of [patches](https://anonscm.debian.org/cgit/users/else-guest/jq.git/tree/debian/patches) that are applied to the source in order to be compliant with the Debian policy and fix Lintian warnings.

Particularly, the following things could be improved:
* include version in tagged releases (without requiring .git): #434 
* split up documentation build so that manpage can be built with minimum set of dependencies: #435

This time jq had to be repackaged in order to remove a minified Bootstrap Javascript resource (DFSG requirement). Please consider splitting up jq-src and homepage source.

Thank you for your work!