### PR TITLE
Resolves issue #1013

### DIFF
--- a/src/jv.h
+++ b/src/jv.h
@@ -18,6 +18,16 @@ typedef enum {
 
 struct jv_refcnt;
 
+
+struct jv_extra_opt_t {
+  uint32_t flag;
+  int array_fold;
+  int array_fold_indent;
+};
+
+typedef struct jv_extra_opt_t jv_extra_opt;
+
+
 /* All of the fields of this struct are private.
    Really. Do not play with them. */
 typedef struct {
@@ -177,6 +187,10 @@ enum jv_print_flags {
     ((n) < 0 || (n) > 7 ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) == 0 ? 0 : (n) << 8 | JV_PRINT_PRETTY)
 void jv_dumpf(jv, FILE *f, int flags);
 void jv_dump(jv, int flags);
+
+void jv_dumpf_extra_opt(jv, FILE *f, int flags, jv_extra_opt *extra_opt);
+void jv_dump_extra_opt(jv, int flags, jv_extra_opt *extra_opt);
+
 void jv_show(jv, int flags);
 jv jv_dump_string(jv, int flags);
 char *jv_dump_string_trunc(jv x, char *outbuf, size_t bufsize);

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -426,7 +426,7 @@ static void jv_dump_term_extra_opt(struct dtoa_context* C, jv x, int flags, int 
             put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
           }
 
-          else if ((i!=array_ele_counter) && (array_ele_counter==1)) {
+          else if ((i!=array_ele_counter) && (array_ele_counter==0)) {
             put_str(",\n", F, S, flags & JV_PRINT_ISATTY);
             put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
           }
@@ -450,8 +450,9 @@ static void jv_dump_term_extra_opt(struct dtoa_context* C, jv x, int flags, int 
 
       if (jv_get_kind(elem)!=JV_KIND_NUMBER) {
         array_ele_counter=0;
+      } else {
+        array_ele_counter++;
       }
-      array_ele_counter++;
 
     }
 

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -426,6 +426,11 @@ static void jv_dump_term_extra_opt(struct dtoa_context* C, jv x, int flags, int 
             put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
           }
 
+          else if ((i!=array_ele_counter) && (array_ele_counter==1)) {
+            put_str(",\n", F, S, flags & JV_PRINT_ISATTY);
+            put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
+          }
+
           else if ((array_ele_counter>0)&&(array_ele_counter%fold)==0) {
             put_str(",\n", F, S, flags & JV_PRINT_ISATTY);
             put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -346,3 +346,206 @@ char *jv_dump_string_trunc(jv x, char *outbuf, size_t bufsize) {
   jv_free(x);
   return outbuf;
 }
+
+static void jv_dump_term_extra_opt(struct dtoa_context* C, jv x, int flags, int indent, FILE* F, jv* S, jv_extra_opt *extra_opt) {
+  int fold=1, array_ele_counter=0;
+  char buf[JVP_DTOA_FMT_MAX_LEN];
+  const char* color = 0;
+  double refcnt = (flags & JV_PRINT_REFCOUNT) ? jv_get_refcnt(x) - 1 : -1;
+
+  if (extra_opt) { fold = extra_opt->array_fold; }
+
+  if (flags & JV_PRINT_COLOR) {
+    for (unsigned i=0; i<sizeof(color_kinds)/sizeof(color_kinds[0]); i++) {
+      if (jv_get_kind(x) == color_kinds[i]) {
+        color = colors[i];
+        put_str(color, F, S, flags & JV_PRINT_ISATTY);
+        break;
+      }
+    }
+  }
+  switch (jv_get_kind(x)) {
+  default:
+  case JV_KIND_INVALID:
+    if (flags & JV_PRINT_INVALID) {
+      jv msg = jv_invalid_get_msg(jv_copy(x));
+      if (jv_get_kind(msg) == JV_KIND_STRING) {
+        put_str("<invalid:", F, S, flags & JV_PRINT_ISATTY);
+        jvp_dump_string(msg, flags | JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
+        put_str(">", F, S, flags & JV_PRINT_ISATTY);
+      } else {
+        put_str("<invalid>", F, S, flags & JV_PRINT_ISATTY);
+      }
+    } else {
+      assert(0 && "Invalid value");
+    }
+    break;
+  case JV_KIND_NULL:
+    put_str("null", F, S, flags & JV_PRINT_ISATTY);
+    break;
+  case JV_KIND_FALSE:
+    put_str("false", F, S, flags & JV_PRINT_ISATTY);
+    break;
+  case JV_KIND_TRUE:
+    put_str("true", F, S, flags & JV_PRINT_ISATTY);
+    break;
+  case JV_KIND_NUMBER: {
+    double d = jv_number_value(x);
+    if (d != d) {
+      // JSON doesn't have NaN, so we'll render it as "null"
+      put_str("null", F, S, flags & JV_PRINT_ISATTY);
+    } else {
+      // Normalise infinities to something we can print in valid JSON
+      if (d > DBL_MAX) d = DBL_MAX;
+      if (d < -DBL_MAX) d = -DBL_MAX;
+      put_str(jvp_dtoa_fmt(C, buf, d), F, S, flags & JV_PRINT_ISATTY);
+    }
+    break;
+  }
+  case JV_KIND_STRING:
+    jvp_dump_string(x, flags & JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
+    if (flags & JV_PRINT_REFCOUNT)
+      put_refcnt(C, refcnt, F, S, flags & JV_PRINT_ISATTY);
+    break;
+  case JV_KIND_ARRAY: {
+    if (jv_array_length(jv_copy(x)) == 0) {
+      put_str("[]", F, S, flags & JV_PRINT_ISATTY);
+      break;
+    }
+    put_str("[", F, S, flags & JV_PRINT_ISATTY);
+    if (flags & JV_PRINT_PRETTY) {
+      put_char('\n', F, S, flags & JV_PRINT_ISATTY);
+      put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
+    }
+    jv_array_foreach(x, i, elem) {
+      if (i!=0) {
+        if (flags & JV_PRINT_PRETTY) {
+
+          if (jv_get_kind(elem)!=JV_KIND_NUMBER) {
+            put_str(",\n", F, S, flags & JV_PRINT_ISATTY);
+            put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
+          }
+
+          else if ((array_ele_counter>0)&&(array_ele_counter%fold)==0) {
+            put_str(",\n", F, S, flags & JV_PRINT_ISATTY);
+            put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
+          }
+
+          else {
+            put_str(", ", F, S, flags & JV_PRINT_ISATTY);
+          }
+
+        } else {
+          put_str(",", F, S, flags & JV_PRINT_ISATTY);
+        }
+      }
+     
+      jv_dump_term_extra_opt(C, elem, flags, indent + 1, F, S, extra_opt);
+      if (color) put_str(color, F, S, flags & JV_PRINT_ISATTY);
+
+      if (jv_get_kind(elem)!=JV_KIND_NUMBER) {
+        array_ele_counter=0;
+      }
+      array_ele_counter++;
+
+    }
+
+    if (flags & JV_PRINT_PRETTY) {
+      put_char('\n', F, S, flags & JV_PRINT_ISATTY);
+      put_indent(indent, flags, F, S, flags & JV_PRINT_ISATTY);
+    }
+    if (color) put_str(color, F, S, flags & JV_PRINT_ISATTY);
+    put_char(']', F, S, flags & JV_PRINT_ISATTY);
+    if (flags & JV_PRINT_REFCOUNT)
+      put_refcnt(C, refcnt, F, S, flags & JV_PRINT_ISATTY);
+    break;
+  }
+  case JV_KIND_OBJECT: {
+    if (jv_object_length(jv_copy(x)) == 0) {
+      put_str("{}", F, S, flags & JV_PRINT_ISATTY);
+      break;
+    }
+    put_char('{', F, S, flags & JV_PRINT_ISATTY);
+    if (flags & JV_PRINT_PRETTY) {
+      put_char('\n', F, S, flags & JV_PRINT_ISATTY);
+      put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
+    }
+    int first = 1;
+    int i = 0;
+    jv keyset = jv_null();
+    while (1) {
+      jv key, value;
+      if (flags & JV_PRINT_SORTED) {
+        if (first) {
+          keyset = jv_keys(jv_copy(x));
+          i = 0;
+        } else {
+          i++;
+        }
+        if (i >= jv_array_length(jv_copy(keyset))) {
+          jv_free(keyset);
+          break;
+        }
+        key = jv_array_get(jv_copy(keyset), i);
+        value = jv_object_get(jv_copy(x), jv_copy(key));
+      } else {
+        if (first) {
+          i = jv_object_iter(x);
+        } else {
+          i = jv_object_iter_next(x, i);
+        }
+        if (!jv_object_iter_valid(x, i)) break;
+        key = jv_object_iter_key(x, i);
+        value = jv_object_iter_value(x, i);
+      }
+
+      if (!first) {
+        if (flags & JV_PRINT_PRETTY){
+          put_str(",\n", F, S, flags & JV_PRINT_ISATTY);
+          put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
+        } else {
+          put_str(",", F, S, flags & JV_PRINT_ISATTY);
+        }
+      }
+      if (color) put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);
+
+      first = 0;
+      if (color) put_str(FIELD_COLOR, F, S, flags & JV_PRINT_ISATTY);
+      jvp_dump_string(key, flags & JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
+      jv_free(key);
+      if (color) put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);
+
+      if (color) put_str(color, F, S, flags & JV_PRINT_ISATTY);
+      put_str((flags & JV_PRINT_PRETTY) ? ": " : ":", F, S, flags & JV_PRINT_ISATTY);
+      if (color) put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);
+
+      jv_dump_term_extra_opt(C, value, flags, indent + 1, F, S, extra_opt);
+      if (color) put_str(color, F, S, flags & JV_PRINT_ISATTY);
+    }
+    if (flags & JV_PRINT_PRETTY) {
+      put_char('\n', F, S, flags & JV_PRINT_ISATTY);
+      put_indent(indent, flags, F, S, flags & JV_PRINT_ISATTY);
+    }
+    if (color) put_str(color, F, S, flags & JV_PRINT_ISATTY);
+    put_char('}', F, S, flags & JV_PRINT_ISATTY);
+    if (flags & JV_PRINT_REFCOUNT)
+      put_refcnt(C, refcnt, F, S, flags & JV_PRINT_ISATTY);
+  }
+  }
+  jv_free(x);
+  if (color) {
+    put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);
+  }
+}
+
+
+void jv_dumpf_extra_opt(jv x, FILE *f, int flags, jv_extra_opt *extra_opt) {
+  struct dtoa_context C;
+  jvp_dtoa_context_init(&C);
+  jv_dump_term_extra_opt(&C, x, flags, 0, f, 0, extra_opt);
+  jvp_dtoa_context_free(&C);
+}
+
+void jv_dump_extra_opt(jv x, int flags, jv_extra_opt *extra_opt) {
+  jv_dumpf_extra_opt(x, stdout, flags, extra_opt);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,7 @@ static void usage(int code) {
     "\t --arg a v\tset variable $a to value <v>;\n"
     "\t --argjson a v\tset variable $a to JSON value <v>;\n"
     "\t --slurpfile a f\tset variable $a to an array of JSON texts read from <f>;\n"
+    "\t --fold w\tprint number array elements <w> to a line;\n"
     "\tSee the manpage for more options.\n", JQ_VERSION, progname);
   exit((ret < 0 && code == 0) ? 2 : code);
 }


### PR DESCRIPTION
Added a '--fold' option to the command line.  As discussed in the issue, this only affects pretty printing and numbers in a list.

A new `process` was created along with `jv_print_extra_opt` to leave the original functions untouched.

There is an unused structure variable in the `jv_extra_opt` for indentation that could be used later.

Testing is minimal (I tested it on a few examples, some of which appeared in #1013).  I wasn't sure how to incorporate these changes in the tests that I saw.