### PR TITLE
Fix manual signature for `split` (non-regex)

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1428,7 +1428,7 @@ sections:
             input: '[65, 66, 67]'
             output: ['"ABC"']
 
-      - title: "`split`"
+      - title: "`split(str)`"
         body: |
 
           Splits an input string on the separator argument.


### PR DESCRIPTION
The documentation for `split` is inconsistent with the rest, as the function requires an argument which is not shown in the signature.