### PR TITLE
update docs to use dnf instead of yum

### DIFF
--- a/docs/content/2.download/default.yml
+++ b/docs/content/2.download/default.yml
@@ -22,7 +22,7 @@ body:
 
        * jq 1.5 is in the official
          [Fedora](http://pkgs.fedoraproject.org/cgit/jq.git/) repository.
-         Install using `sudo yum install jq`.
+         Install using `sudo dnf install jq`.
 
        * jq 1.4 is in the official [openSUSE](https://software.opensuse.org/package/jq)
          repository. Install using `sudo zypper install jq`.


### PR DESCRIPTION
`yum` has been replaced with `dnf` as of f22, using yum will give you a deprecation warning. see https://fedoraproject.org/wiki/Changes/ReplaceYumWithDNF for more info