### PR TITLE
Make it easier to use jq with shebangs (fix #1044)

### DIFF
--- a/tests/jq-f-test.sh
+++ b/tests/jq-f-test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# this next line is ignored by jq, which otherwise does not continue comments \
+exec jq -nef "$0" "$@"
+true

--- a/tests/shtest
+++ b/tests/shtest
@@ -2,6 +2,8 @@
 
 . "${0%/*}/setup"
 
+PATH=$JQBASEDIR:$PATH $JQBASEDIR/tests/jq-f-test.sh > /dev/null
+
 if [ -f "$JQBASEDIR/.libs/libinject_errors.so" ]; then
   # Do some simple error injection tests to check that we're handling
   # I/O errors correctly.


### PR DESCRIPTION
Allow a continuation on a comment immediately after a shebang to make
this traditional hack possible:

    #!/bin/sh
    # this next line is ignored by jq \
    exec jq -f "$0" "$@"
    # jq code follows

But continue only on the first line following a shebang, and only if
it's a comment.