### PR TITLE
Mention keywords "cast" and "integer" in "tonumber" docs

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1111,6 +1111,8 @@ sections:
           will convert correctly-formatted strings to their numeric
           equivalent, leave numbers alone, and give an error on all other input.
 
+          It casts the string into an integer or a float, depending on its value.
+
         examples:
           - program: '.[] | tonumber'
             input: '[1, "1"]'


### PR DESCRIPTION
When searching for a way to cast a string to integer with `jq`, I did not find any results. Thus I'm adding the keywords "cast" and "integer" for future search engine users.