### PR TITLE
Build 32bit and run tests on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - file jq.exe
   
 test_script:
-  - echo not run?
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make check"
       
 artifacts:
   - path: jq-package.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,8 @@ build_script:
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && autoreconf -i"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --disable-shared --enable-static --enable-all-static"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make LDFLAGS=-lshlwapi"
-  - 7z a jq-package.zip jq.1 jq.exe
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && cat jq.1  | groff -mandoc -Thtml > jq.html"
+  - 7z a jq-package.zip jq.1 jq.html jq.exe
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && pwd && ls -la"
   - file jq.exe
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,3 +33,13 @@ artifacts:
   - path: jq.exe
     name: jq-exe
     
+  - path: test-suite.log
+    name: logs
+    
+
+on_failure:
+  - cat test-suite.log
+  - appveyor PushArtifact test-suite.log
+  # also push the jq.exe so that someone can download it anyways...
+  - appveyor PushArtifact jq-package.zip
+    

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,16 @@
-﻿environment:
+environment:
   matrix:
-  - Compiler: mingw
+  - MSYSTEM: MINGW64
+    PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
+  - MSYSTEM: MINGW32
+    PATH: C:\msys64\usr\bin;C:\msys64\mingw32\bin;C:\Windows\System32;C:\Windows;%PATH%
 
 
 install:
-  - set "PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%"
-  - set MSYSTEM=MINGW64
   # update mysy2
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
-  # this crashes? 
-  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-i686-toolchain" 
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex"
-  # install oniguruma
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-i686-oniguruma mingw-w64-x86_64-oniguruma"
 
 
@@ -22,6 +20,7 @@ build_script:
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make LDFLAGS=-lshlwapi"
   - 7z a jq-package.zip jq.1 jq.exe
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && pwd && ls -la"
+  - file jq.exe
   
 test_script:
   - echo not run?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+﻿environment:
+  matrix:
+  - Compiler: mingw
+
+
+install:
+  - set "PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%"
+  - set MSYSTEM=MINGW64
+  # update mysy2
+  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
+  # this crashes? 
+  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-i686-toolchain" 
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex"
+  # install oniguruma
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-i686-oniguruma mingw-w64-x86_64-oniguruma"
+
+
+build_script:
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && autoreconf -i"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --disable-shared --enable-static --enable-all-static"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make LDFLAGS=-lshlwapi"
+  - 7z a jq-package.zip jq.1 jq.exe
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && pwd && ls -la"
+  
+test_script:
+  - echo not run?
+      
+artifacts:
+  - path: jq-package.zip
+    name: jq-package
+    
+  - path: jq.exe
+    name: jq-exe
+    


### PR DESCRIPTION
This is a addon to https://github.com/stedolan/jq/pull/1074 (including that PR), which adds

* 32bit builds (currently failing)
* html help files from the man pages
* run the test suite (currently failing)

64bit build logs: https://ci.appveyor.com/project/JanSchulz/jq/build/job/5lca2kfdijltolej
32bit build logs: https://ci.appveyor.com/project/JanSchulz/jq/build/job/4jolgdm69b7qfofq