### PR TITLE
Revert "Disable appveyor build for now"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,43 +8,42 @@ environment:
 
 install:
   # update mysy2
-  #- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
-  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
-  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex"
-  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-i686-oniguruma mingw-w64-x86_64-oniguruma"
+  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-i686-oniguruma mingw-w64-x86_64-oniguruma"
 
 
 build_script:
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && autoreconf -i"
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --disable-shared --enable-static --enable-all-static"
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make -j8"
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && cat jq.1  | groff -mandoc -Thtml > jq.html"
-  #- 7z a jq-package.zip jq.1 jq.html jq.exe
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && pwd && ls -la"
-  #- file jq.exe
-  - bash -lc true
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && autoreconf -i"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --disable-shared --enable-static --enable-all-static"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make -j8"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && cat jq.1  | groff -mandoc -Thtml > jq.html"
+  - 7z a jq-package.zip jq.1 jq.html jq.exe
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && pwd && ls -la"
+  - file jq.exe
   
-  #test_script:
+test_script:
   # tests/optionaltest and tests/shtest fail on Windows; run them
   # anyways but ignore their failures.  Also, trace shtest.
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make -j3 'TESTS=tests/mantest tests/jqtest tests/onigtest' check"
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make TESTS=tests/optionaltest check || cat test-suite.log"
-  #- bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make TRACE_TESTS=1 TESTS=tests/shtest check || cat test-suite.log"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make -j3 'TESTS=tests/mantest tests/jqtest tests/onigtest' check"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make TESTS=tests/optionaltest check || cat test-suite.log"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make TRACE_TESTS=1 TESTS=tests/shtest check || cat test-suite.log"
       
-  #artifacts:
-  #- path: jq-package.zip
-  # name: jq-package
+artifacts:
+  - path: jq-package.zip
+    name: jq-package
     
-  #- path: jq.exe
-  #  name: jq-exe
+  - path: jq.exe
+    name: jq-exe
     
-  #- path: test-suite.log
-  #  name: logs
+  - path: test-suite.log
+    name: logs
     
 
-  #on_failure:
-  #- cat test-suite.log
-  #- appveyor PushArtifact test-suite.log
+on_failure:
+  - cat test-suite.log
+  - appveyor PushArtifact test-suite.log
   # also push the jq.exe so that someone can download it anyways...
-  #- appveyor PushArtifact jq-package.zip
+  - appveyor PushArtifact jq-package.zip
     


### PR DESCRIPTION
This reverts commit 0b8218515eabf1a967eba0dbcc7a0e5ae031a509.

There is a new oniguruma package which previously trashed the build.
