### PR TITLE
Update ArchLinux dowload url

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -85,7 +85,7 @@
 </li>
 
 <li>
-<p>For Arch users, a PKGBUILD is in the <a href="https://aur.archlinux.org/packages/jq-git/">AUR</a>. Refer to the <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository">ArchWiki</a> for how to install from AUR.</p>
+<p>jq 1.5 is in the official <a href="https://www.archlinux.org/packages/jq">ArchLinux</a> repositories. Intall using <code>sudo pacman -S jq</code>.</p>
 </li>
 
 <li>

--- a/download/index.html
+++ b/download/index.html
@@ -85,7 +85,7 @@
 </li>
 
 <li>
-<p>jq 1.5 is in the official <a href="https://www.archlinux.org/packages/jq">ArchLinux</a> repositories. Intall using <code>sudo pacman -S jq</code>.</p>
+<p>jq 1.5 is in the official <a href="https://www.archlinux.org/packages/jq">ArchLinux</a> repositories. Install using <code>sudo pacman -S jq</code>.</p>
 </li>
 
 <li>


### PR DESCRIPTION
Actually jq package has been moved into official repositories some time ago. I believe users don't need to build the application from git repository directly and may just install compiled application from repositories
