### PR TITLE
timegm() on Solaris and derived requires __EXTENSIONS__.

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 #define _XOPEN_SOURCE
 #define _XOPEN_SOURCE_EXTENDED 1
+#define _XPG6
 #define __EXTENSIONS__
 #include <sys/time.h>
 #include <stdlib.h>

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 #define _XOPEN_SOURCE
 #define _XOPEN_SOURCE_EXTENDED 1
+#define __EXTENSIONS__
 #include <sys/time.h>
 #include <stdlib.h>
 #include <stddef.h>


### PR DESCRIPTION
This fixes compilation on Solaris and derived operating systems.