### PR TITLE
Solaris needs XPG6 for c99

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1,7 +1,12 @@
 #define _BSD_SOURCE
 #define _GNU_SOURCE
-#define _XOPEN_SOURCE
-#define _XOPEN_SOURCE_EXTENDED 1
+#ifndef __sun__
+# define _XOPEN_SOURCE
+# define _XOPEN_SOURCE_EXTENDED 1
+#else
+# define _XPG6
+# define __EXTENSIONS__
+#endif
 #include <sys/time.h>
 #include <stdlib.h>
 #include <stddef.h>


### PR DESCRIPTION
This fixes compilation on Solaris and derived operating systems.
