### PR TITLE
Introduce limits on max parsing and printing depth

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -10,6 +10,10 @@
 
 typedef const char* presult;
 
+#ifndef MAX_PARSING_DEPTH
+#define MAX_PARSING_DEPTH (256)
+#endif
+
 #define TRY(x) do {presult msg__ = (x); if (msg__) return msg__; } while(0)
 #ifdef __GNUC__
 #define pfunc __attribute__((warn_unused_result)) presult
@@ -147,11 +151,13 @@ static void push(struct jv_parser* p, jv v) {
 static pfunc parse_token(struct jv_parser* p, char ch) {
   switch (ch) {
   case '[':
+    if (p->stackpos >= MAX_PARSING_DEPTH) return "Exceeds depth limit for parsing";
     if (jv_is_valid(p->next)) return "Expected separator between values";
     push(p, jv_array());
     break;
 
   case '{':
+    if (p->stackpos >= MAX_PARSING_DEPTH) return "Exceeds depth limit for parsing";
     if (jv_is_valid(p->next)) return "Expected separator between values";
     push(p, jv_object());
     break;

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -13,6 +13,10 @@
 #include "jv_dtoa.h"
 #include "jv_unicode.h"
 
+#ifndef MAX_PRINT_DEPTH
+#define MAX_PRINT_DEPTH (256)
+#endif
+
 #define ESC "\033"
 #define COL(c) (ESC "[" c "m")
 #define COLRESET (ESC "[0m")
@@ -150,7 +154,9 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
       }
     }
   }
-  switch (jv_get_kind(x)) {
+  if (indent > MAX_PRINT_DEPTH) {
+    put_str("<skipped: too deep>", F, S, flags & JV_PRINT_ISATTY);
+  } else switch (jv_get_kind(x)) {
   default:
   case JV_KIND_INVALID:
     if (flags & JV_PRINT_INVALID) {


### PR DESCRIPTION
Avoids _jq_ getting killed for running out-of stack.

Fixes: CVE-2016-4074 (and another)