### PR TITLE
Add summary_stats and variant builtins

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1231,6 +1231,28 @@ sections:
             input: '[{"foo":1, "bar":14}, {"foo":2, "bar":3}]'
             output: ['{"foo":2, "bar":3}']
 
+      - title: "`summary_stats`, `mean`, `variance`, `sample_variance`"
+        body: |
+
+          Compute summary statistics on an array of numbers.
+
+          `mean`, `variance`, and `sample_variance` compute mean, population
+          variance, and sample variance respectively. The output of
+          `summary_stats` is an object with five fields, "count", "mean",
+          "min", "max", and "sumsq". "sumsq" is the sum of squared differences
+          from the mean, everything else has the obvious definition.  If the
+          input list is empty, every field but count is `nan`. Computing the
+          mean through these filters is slightly faster and more stable than
+          `add / length`.
+
+        examples:
+          - program: 'summary_stats'
+            input: '[5,4,2,7]'
+            output: ['{"count":4,"mean":4.5,"sumsq":13,"min":2,"max":7}']
+          - program: 'sample_variance'
+            input: '[5,4,2,7,9]'
+            output: ['7.3']
+
       - title: "`unique`, `unique_by(path_exp)`"
         body: |
 

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -857,6 +857,43 @@ static jv f_max_by_impl(jq_state *jq, jv x, jv y) {
   return minmax_by(x, y, 0);
 }
 
+static jv f_summary_stats(jq_state *jq, jv values) {
+  // Takes an array of numbers and computes count, mean, min, max, and sum of
+  // squared mean differences
+  if (jv_get_kind(values) != JV_KIND_ARRAY)
+    return type_error(values, "cannot be iterated over");
+  int count = 0;
+  double mean = 0;
+  double sumsq = 0;
+  double min = INFINITY;
+  double max = -INFINITY;
+
+  for (int i=0; i<jv_array_length(jv_copy(values)); i++) {
+    jv item = jv_array_get(jv_copy(values), i);
+    jv_kind k = jv_get_kind(item);
+    if (k != JV_KIND_NUMBER) {
+      jv_free(values);
+      return type_error(item, "number required");
+    }
+    double val = jv_number_value(item);
+    double delta = val - mean;
+    jv_free(item);
+    mean += delta / ++count;
+    sumsq += delta * (val - mean);
+    max = fmax(max, val);
+    min = fmin(min, val);
+  }
+  jv_free(values);
+
+  jv ret = jv_object();
+  jv_object_set(ret, jv_string("count"), jv_number(count));
+  jv_object_set(ret, jv_string("mean"), jv_number(count ? mean: NAN));
+  jv_object_set(ret, jv_string("sumsq"), jv_number(count ? sumsq : NAN));
+  jv_object_set(ret, jv_string("min"), jv_number(count ? min: NAN));
+  jv_object_set(ret, jv_string("max"), jv_number(count ? max: NAN));
+  return ret;
+}
+
 
 static jv f_type(jq_state *jq, jv input) {
   jv out = jv_string(jv_kind_name(jv_get_kind(input)));
@@ -1294,6 +1331,7 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_max, "max", 1},
   {(cfunction_ptr)f_min_by_impl, "_min_by_impl", 2},
   {(cfunction_ptr)f_max_by_impl, "_max_by_impl", 2},
+  {(cfunction_ptr)f_summary_stats, "summary_stats", 1},
   {(cfunction_ptr)f_error, "error", 2},
   {(cfunction_ptr)f_format, "format", 2},
   {(cfunction_ptr)f_env, "env", 1},

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -278,6 +278,11 @@ def bsearch(target):
       end
   end;
 
+# Convience names for `summary_stats` functions
+def mean: summary_stats | .mean;
+def variance: summary_stats | .sumsq / .count;
+def sample_variance: if length < 2 then nan else summary_stats | .sumsq / (.count - 1) end;
+
 # Apply f to composite entities recursively, and to atoms
 def walk(f):
   . as $in

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1190,6 +1190,52 @@ bsearch(4)
 [1,2,3]
 -4
 
+# Tests of summary_stats method
+# -----------------------------
+# with_entries is necessary to get nan comparison to work
+summary_stats | with_entries({key: .key, value: (.value | if isnan then null else . end)})
+[]
+{"count": 0, "min": null, "max": null, "mean": null, "sumsq": null}
+
+# Not iterable
+summary_stats
+5
+
+
+# Not a number
+summary_stats
+[1, 2, null]
+
+
+# Test pathalogical numeric precision
+# This is based off of precision, so if jq ends up using 128 bit floats, this
+# will break
+add / length == 2000000000000000
+[100000000000000001, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+true
+
+mean > 2000000000000000
+[100000000000000001, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+true
+
+# Test aliases
+mean
+[1, 2, 3]
+2
+
+variance
+[1, 3, 5, 3]
+2
+
+sample_variance
+[1, 3, 5]
+4
+
+sample_variance | if isnan then null else . end
+[1]
+null
+
+
 # strptime tests are in optional.test
 
 strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
I worry this is getting in the realm of builtin bloat, but this adds a c function that computes mean, variance, min, and max in one pass. In addition to being more stable than doing it like `(add / length) as $mean | map((. - $mean) * (. - $mean)) | add / length` it is much faster than anything I could do in native jq.

The contributor guides indicated that keeping objects as jv is preferred. Here I explicitly do the arithmetic on doubles, but since the function mandates the inputs be numbers anyway, this seems like the correct way to go.

I didn't see a builtin way to do coverage, but every branch should be reasonably covered by the tests.