### PR TITLE
Fix cross-compile tmp dir removal

### DIFF
--- a/scripts/crosscompile
+++ b/scripts/crosscompile
@@ -38,5 +38,6 @@ set -x
 for jq in `find . -type f \( -name jq -o -name jq.exe \) -print`; do
     cp "$jq" ..
 done
+cd ..
 rm -rf tmp
 


### PR DESCRIPTION
- cd out of the tmp dir before attempting to remove it.

---

Changes in 5d9d1b1 broke removal of the temporary directory.
