### PR TITLE
Typo: s/more/mode/ in `--seq`

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -107,7 +107,7 @@ sections:
         output and an ASCII LF (line feed) is printed after every
         output.  Input JSON texts that fail to parse are ignored (but
         warned about), discarding all subsequent input until the next
-        RS.  This more also parses the output of jq without the `--seq`
+        RS.  This mode also parses the output of jq without the `--seq`
         option.
 
       * `--stream`:


### PR DESCRIPTION
I'm not actually sure I understand that sentence, but it does appear to be a typo either way.