### PR TITLE
Mark startswith() and endswith() with "Since 1.4"

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1353,7 +1353,7 @@ sections:
       - title: "`startswith(str)`"
         body: |
 
-          Outputs `true` if . starts with the given string argument.
+          Outputs `true` if . starts with the given string argument. Since 1.4.
 
         examples:
           - program: '[.[]|startswith("foo")]'
@@ -1363,7 +1363,7 @@ sections:
       - title: "`endswith(str)`"
         body: |
 
-          Outputs `true` if . ends with the given string argument.
+          Outputs `true` if . ends with the given string argument. Since 1.4.
 
         examples:
           - program: '[.[]|endswith("foo")]'


### PR DESCRIPTION
It took me some time to figure out why the documented "startswith()" and "endswith()" [1] do not work. The reason: I'm using version 1.3. But the manual does not have an information since which version a feature exists. A simple "Since 1.4" would have helped a lot!


[1] https://stedolan.github.io/jq/manual/