### PR TITLE
Fix input_(line_number|filename) leak memory

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1227,14 +1227,17 @@ static jv f_now(jq_state *jq, jv a) {
 }
 #endif
 
-static jv f_current_filename(jq_state *jq) {
+static jv f_current_filename(jq_state *jq, jv a) {
+  jv_free(a);
+
   jv r = jq_util_input_get_current_filename(jq);
   if (jv_is_valid(r))
     return r;
   jv_free(r);
   return jv_null();
 }
-static jv f_current_line(jq_state *jq) {
+static jv f_current_line(jq_state *jq, jv a) {
+  jv_free(a);
   return jq_util_input_get_current_line(jq);
 }
 


### PR DESCRIPTION
# Fix input_(line_number|filename) leak memory

While dealing with large files, I noticed that `input_line_number` seemed to trigger large memory usage.

Following test cases show that unless input is a boolean, memory usage grows linearly with input size:

```bash
# Constant memory usage when input is a boolean

$ for i in $(seq 4 7); do     
    yes 'true' | head -n $((10**$i)) | time -f "max rss: %M time: %E" jq -c 'input_line_number' | wc -l;   done
max rss: 2376 time: 0:00.01
10000
max rss: 2324 time: 0:00.10
100000
max rss: 2352 time: 0:00.98
1000000
max rss: 2284 time: 0:10.09
10000000


# Linear memory usage when input is a string / array / object

$ for i in $(seq 4 7); do 
    yes '"foo"' | head -n $((10**$i)) | time -f "max rss: %M time: %E" jq -c 'input_line_number' | wc -l 
  done
max rss: 2612 time: 0:00.01
10000
max rss: 5380 time: 0:00.12
100000
max rss: 33532 time: 0:01.07
1000000
max rss: 314876 time: 0:10.99
10000000

$ for i in $(seq 4 7); do 
    yes '[]' | head -n $((10**$i)) | time -f "max rss: %M time: %E" jq -c 'input_line_number' | wc -l 
  done
max rss: 5144 time: 0:00.02
10000
max rss: 30476 time: 0:00.14
100000
max rss: 283580 time: 0:01.17
1000000
max rss: 2814820 time: 0:11.99
10000000


$ for i in $(seq 4 7); do 
    yes '{}' | head -n $((10**$i)) | time -f "max rss: %M time: %E" jq -c 'input_line_number' | wc -l 
  done
max rss: 6228 time: 0:00.02
10000
max rss: 41360 time: 0:00.15
100000
max rss: 392888 time: 0:01.32
1000000
max rss: 3908496 time: 0:13.44
10000000
```

Valgrind confirms that some memory is leaked:

```bash
$ yes '"foo"'| head -n 1000 | valgrind --leak-check=yes ./jq 'input_line_number' > /dev/null
==6944== Memcheck, a memory error detector
==6944== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==6944== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==6944== Command: ./jq input_line_number
==6944== 
==6944== 
==6944== HEAP SUMMARY:
==6944==     in use at exit: 20,000 bytes in 1,000 blocks
==6944==   total heap usage: 11,274 allocs, 10,274 frees, 1,469,291 bytes allocated
==6944== 
==6944== 20,000 bytes in 1,000 blocks are definitely lost in loss record 1 of 1
==6944==    at 0x4C2BBAD: malloc (vg_replace_malloc.c:299)
==6944==    by 0x40C468: jv_mem_alloc (jv_alloc.c:122)
==6944==    by 0x40946B: jvp_string_alloc (jv.c:441)
==6944==    by 0x40946B: jvp_string_new (jv.c:474)
==6944==    by 0x40946B: jv_string_sized (jv.c:613)
==6944==    by 0x410575: found_string (jv_parse.c:464)
==6944==    by 0x410575: scan (jv_parse.c:642)
==6944==    by 0x410575: jv_parser_next (jv_parse.c:743)
==6944==    by 0x415091: jq_util_input_next_input (util.c:442)
==6944==    by 0x4025B1: main (main.c:549)
==6944== 
==6944== LEAK SUMMARY:
==6944==    definitely lost: 20,000 bytes in 1,000 blocks
==6944==    indirectly lost: 0 bytes in 0 blocks
==6944==      possibly lost: 0 bytes in 0 blocks
==6944==    still reachable: 0 bytes in 0 blocks
==6944==         suppressed: 0 bytes in 0 blocks
==6944== 
==6944== For counts of detected and suppressed errors, rerun with: -v
==6944== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

Fiddling with the code, I was able to spot that the issue is that nor `f_current_filename` nor `f_current_line` free their ignored `jv` argument.


Let's check that the issue is fixed:

```bash
$ make -j8 && yes '"foo"'| head -n 1000 | valgrind --leak-check=yes ./jq -c 'input_line_number' > /dev/null
make  all-am
make[1]: Entering directory '/home/cmathieu/Sources/github/stedolan/jq'
make[1]: Leaving directory '/home/cmathieu/Sources/github/stedolan/jq'
==23626== Memcheck, a memory error detector
==23626== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==23626== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==23626== Command: ./jq -c input_line_number
==23626== 
==23626== 
==23626== HEAP SUMMARY:
==23626==     in use at exit: 0 bytes in 0 blocks
==23626==   total heap usage: 11,274 allocs, 11,274 frees, 1,469,291 bytes allocated
==23626== 
==23626== All heap blocks were freed -- no leaks are possible
==23626== 
==23626== For counts of detected and suppressed errors, rerun with: -v
==23626== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Should I had a new test case too ?