### PR TITLE
Add local oniguruma submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "modules/oniguruma"]
+	path = modules/oniguruma
+	url = https://github.com/kkos/oniguruma.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ matrix:
 addons:
     apt:
         packages:
-            - libonig-dev
             - valgrind
             - bison
+            - automake
 
 before_install:
     - echo "$TRAVIS_OS_NAME"
@@ -29,8 +29,8 @@ before_install:
     - brew update               || true;
       brew install flex         || true;
       brew install bison        || true;
-      brew install oniguruma    || true;
     - rm src/{lexer,parser}.{c,h}
+    - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac
 
 install:
     - bundle install --gemfile=docs/Gemfile
@@ -46,7 +46,7 @@ before_script:
     - echo PATH=$PATH
     - which bison
     - bison --version
-    - autoreconf -i
+    - autoreconf -if
     - ./configure YACC="$(which bison) -y" $COVERAGE
 
 script:

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ AM_YFLAGS = --warnings=all -d
 lib_LTLIBRARIES = libjq.la
 libjq_la_SOURCES = ${LIBJQ_SRC}
 libjq_la_LIBADD = -lm
-libjq_la_LDFLAGS = -export-symbols-regex '^j[qv]_' -version-info 1:4:0
+libjq_la_LDFLAGS = $(onig_LDFLAGS) -export-symbols-regex '^j[qv]_' -version-info 1:4:0
 
 if WIN32
 libjq_la_LIBADD += -lshlwapi
@@ -132,6 +132,15 @@ jq.1: $(srcdir)/jq.1.prebuilt
 	$(AM_V_GEN) cp $^ $@
 endif
 
+
+### Build oniguruma
+
+if BUILD_ONIGURUMA
+libjq_la_LIBADD += modules/oniguruma/src/.libs/libonig.la
+SUBDIRS = modules/oniguruma
+endif
+
+AM_CFLAGS += $(onig_CFLAGS)
 
 ### Packaging
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,35 +44,6 @@ if test "$USE_MAINTAINER_MODE" = yes; then
   fi
 fi
 
-
-##########################################################################
-# check for ONIGURUMA library
-##########################################################################
-
-AC_ARG_WITH([oniguruma],
-    [AS_HELP_STRING([--with-oniguruma=prefix],
-        [try this for a non-standard install prefix of the oniguruma library])],
-    [],
-    [with_oniguruma=yes])
-
-AS_IF([test "x$with_oniguruma" != xno], [
-    AS_IF([test "x$with_oniguruma" != xyes], [
-        CFLAGS="$CFLAGS -I${with_oniguruma}/include"
-        LDFLAGS="$LDFLAGS -L${with_oniguruma}/lib"
-    ])
-    # check for ONIGURUMA library
-    have_oniguruma=0
-    AC_CHECK_HEADER("oniguruma.h",
-        AC_CHECK_LIB([onig],[onig_version],[LIBS="$LIBS -lonig"; have_oniguruma=1;]))
-    # handle check results
-    AS_IF([test $have_oniguruma = 1], [
-        AC_DEFINE([HAVE_ONIGURUMA], 1, [Define to 1 if Oniguruma is installed])
-    ], [
-        AC_MSG_NOTICE([Oniguruma was not found.])
-        AC_MSG_NOTICE([Try setting the location using '--with-oniguruma=PREFIX'])
-    ])
-])
-
 dnl Check for valgrind
 AC_CHECK_PROGS(valgrind_cmd, valgrind)
 if test "x$valgrind_cmd" = "x" ; then
@@ -254,6 +225,41 @@ AC_C_BIGENDIAN(
    AC_MSG_ERROR(universial endianess not supported)
 )
 
+dnl Oniguruma
+AC_ARG_WITH([oniguruma],
+   [AS_HELP_STRING([--with-oniguruma=prefix],
+      [try this for a non-standard install prefix of the oniguruma library])], ,
+   [with_oniguruma=yes])
+
+build_oniguruma=no
+AS_IF([test "x$with_oniguruma" != xno], [
+   save_CFLAGS="$CFLAGS"
+   save_LDFLAGS="$LDFLAGS"
+   AS_IF([test "x$with_oniguruma" != xyes], [
+      onig_CFLAGS="-I${with_oniguruma}/include"
+      onig_LDFLAGS="-L${with_oniguruma}/lib"
+      CFLAGS="$CFLAGS $onig_CFLAGS"
+      LDFLAGS="$LDFLAGS $onig_LDFLAGS"
+   ])
+   # check for ONIGURUMA library
+   AC_CHECK_HEADER("oniguruma.h",
+      AC_CHECK_LIB([onig],[onig_version]))
+   CFLAGS="$save_CFLAGS"
+   LDFLAGS="$save_LDFLAGS"
+
+   # handle check results
+   AS_IF([test "x$ac_cv_lib_onig_onig_version" != "xyes"], [
+      onig_CFLAGS="-I${srcdir}/modules/oniguruma/src"
+      onig_LDFLAGS=
+      AC_CONFIG_SUBDIRS([modules/oniguruma])
+      build_oniguruma=yes
+      AC_MSG_NOTICE([Oniguruma was not found. Will use the packaged oniguruma.])
+   ])
+   AC_SUBST(onig_CFLAGS)
+   AC_SUBST(onig_LDFLAGS)
+])
+
+AM_CONDITIONAL([BUILD_ONIGURUMA], [test "x$build_oniguruma" = xyes])
 AC_SUBST([BUNDLER], ["$bundle_cmd"])
 
 AC_CONFIG_MACRO_DIR([config/m4])

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -29,7 +29,7 @@ void *alloca (size_t);
 #include <ctype.h>
 #include <limits.h>
 #include <math.h>
-#ifdef HAVE_ONIGURUMA
+#ifdef HAVE_LIBONIG
 #include <oniguruma.h>
 #endif
 #include <string.h>
@@ -697,7 +697,7 @@ static jv f_group_by_impl(jq_state *jq, jv input, jv keys) {
   }
 }
 
-#ifdef HAVE_ONIGURUMA
+#ifdef HAVE_LIBONIG
 static int f_match_name_iter(const UChar* name, const UChar *name_end, int ngroups,
     int *groups, regex_t *reg, void *arg) {
   jv captures = *(jv*)arg;
@@ -901,11 +901,11 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
   jv_free(regex);
   return result;
 }
-#else /* ! HAVE_ONIGURUMA */
+#else /* !HAVE_LIBONIG */
 static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
   return jv_invalid_with_msg(jv_string("jq was compiled without ONIGURUMA regex libary. match/test/sub and related functions are not available."));
 }
-#endif /* HAVE_ONIGURUMA */
+#endif /* HAVE_LIBONIG */
 
 static jv minmax_by(jv values, jv keys, int is_min) {
   if (jv_get_kind(values) != JV_KIND_ARRAY)


### PR DESCRIPTION
This is a test to add oniguruma locally as a submodule. This should allow:

- Control over the oniguruma version
- Regex support in all builds
- The potential to cross compile for windows from TravisCI and move away from appveyor

fixes #1059