### PR TITLE
fix truncate_stream to match docs

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -210,7 +210,7 @@ def ascii_upcase:
 
 # Streaming utilities
 def truncate_stream(stream):
-  . as $n | null | stream | . as $input | if (.[0]|length) > $n then setpath([0];$input[0][1:]) else empty end;
+  . as $n | null | stream | . as $input | if (.[0]|length) > $n then setpath([0];$input[0][$n:]) else empty end;
 def fromstream(i):
   foreach i as $item (
     [null,false,null,false];


### PR DESCRIPTION
The current behaviour of `truncate_stream` is to always truncate 1 level from output, and to retain those nodes that would survive a truncation by `$n`. Most likely, this was a typo, since this behaviour doesn't make much sense to me.

This small change fixes it to match docs. Or, did I misunderstand docs completely?