### PR TITLE
Add $ENV builtin variable for access to environment; also fix error msg for unbound vars

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 clone_script:
   - bash -lc "git clone -q --branch=$APPVEYOR_REPO_BRANCH https://github.com/${APPVEYOR_REPO_NAME}.git $APPVEYOR_BUILD_FOLDER"
-  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && git checkout -qf $APPVEYOR_REPO_COMMIT"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && git checkout -qf $APPVEYOR_REPO_BRANCH"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && git submodule update --init --recursive"
 
 install:

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1666,12 +1666,22 @@ sections:
             output:
               - '[{"a":{"b":2}}]'
 
-      - title: "`env`"
+      - title: "`$ENV`, `env`"
         body: |
 
-          Outputs an object representing jq's environment.
+          `$ENV` is an object representing the environment variables as
+          set when the jq program started.
+
+          `env` outputs an object representing jq's current environment.
+
+          At the moment there is no builtin for setting environment
+          variables.
 
         examples:
+          - program: '$ENV.PAGER'
+            input: 'null'
+            output: ['"less"']
+
           - program: 'env.PAGER'
             input: 'null'
             output: ['"less"']

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1830,12 +1830,22 @@ jq \'walk( if type == "object" then with_entries( \.key |= sub( "^_+"; "") ) els
 .
 .IP "" 0
 .
-.SS "env"
-Outputs an object representing jq\'s environment\.
+.SS "$ENV, env"
+\fB$ENV\fR is an object representing the environment variables as set when the jq program started\.
+.
+.P
+\fBenv\fR outputs an object representing jq\'s current environment\.
+.
+.P
+At the moment there is no builtin for setting environment variables\.
 .
 .IP "" 4
 .
 .nf
+
+jq \'$ENV\.PAGER\'
+   null
+=> "less"
 
 jq \'env\.PAGER\'
    null

--- a/src/compile.c
+++ b/src/compile.c
@@ -1007,6 +1007,8 @@ static int expand_call_arglist(block* b) {
       if (!curr->bound_by) {
         if (curr->symbol[0] == '*' && curr->symbol[1] >= '1' && curr->symbol[1] <= '3' && curr->symbol[2] == '\0')
           locfile_locate(curr->locfile, curr->source, "jq: error: break used outside labeled control structure");
+        else if (curr->op == LOADV)
+          locfile_locate(curr->locfile, curr->source, "jq: error: $%s is not defined", curr->symbol);
         else
           locfile_locate(curr->locfile, curr->source, "jq: error: %s/%d is not defined", curr->symbol, block_count_actuals(curr->arglist));
         errors++;

--- a/src/compile.h
+++ b/src/compile.h
@@ -77,7 +77,7 @@ block block_drop_unreferenced(block body);
 jv block_take_imports(block* body);
 jv block_list_funcs(block body, int omit_underscores);
 
-int block_compile(block, struct bytecode**, struct locfile*);
+int block_compile(block, struct bytecode**, struct locfile*, jv);
 
 void block_free(block);
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -278,7 +278,7 @@ null
 
 %%FAIL
 . as $foo | break $foo
-jq: error: *label-foo/0 is not defined at <top-level>, line 1:
+jq: error: $*label-foo is not defined at <top-level>, line 1:
 
 [.[]|[.,1]|until(.[0] < 1; [.[0] - 1, .[1] * .[0]])|.[1]]
 [1,2,3,4,5]


### PR DESCRIPTION
Turns out it's pretty easy to add this.

Also, if we passed in the `$ARGS` object to this function (`compile.c:expand_call_arglist()`) we could greatly speed up the binding of many `--arg*`s to the program: instead of `O(N*M)` we'd have `O(N log M)`, where `N` is the size of the program and `M` is the number of variables...  We should probably do it.