### PR TITLE
Use unsorted keys in walk

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -284,7 +284,7 @@ def bsearch(target):
 def walk(f):
   . as $in
   | if type == "object" then
-      reduce keys[] as $key
+      reduce keys_unsorted[] as $key
         ( {}; . + { ($key):  ($in[$key] | walk(f)) } ) | f
   elif type == "array" then map( walk(f) ) | f
   else f


### PR DESCRIPTION
Preserve key sorting order when executing in walk, if sorted keys is desired `--sort-keys` should be used to explicitly obtain sorted keys.

This caused unexpected behavior when executing jq programs like `jq 'walk(if (type == "object") then with_entries( if .key == "target_key" then .value |= sort else . end ) else . end'`

Before fix:
```json
#Input
{
    "target_key": [
        "def",
        "abc"
    ],
    "another_key": 1
}

#Output
{
    "another_key": 1,
    "target_key": [
        "abc",
        "def"
    ]
}

#Note how key order for "another_key" changed despite it being unrelated to the walk(f) execution
```

After fix:
```json
#Input
{
    "target_key": [
        "def",
        "abc"
    ],
    "another_key": 1
}

#Output
{
    "target_key": [
        "abc",
        "def"
    ],
    "another_key": 1
}

#Note how key order for "another_key" is preserved as expected
```

