### PR TITLE
Dockerfile build fix: oniguruma doesn't have a distclean target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN apt-get update && \
         ./configure --disable-valgrind --enable-all-static --prefix=/usr/local && \
         make -j8 && \
         make check && \
-        make install && \
-        make distclean ) && \
+        make install ) && \
     (cd oniguruma-5.9.6 && \
         make uninstall ) && \
     apt-get purge -y \


### PR DESCRIPTION
I was trying to build a docker image from `master` (because I needed `@base64d`), and the build failed saying there was no "distclean" target for oniguruma.  Removing the corresponding command from the Dockerfile fixed this; presumably the need to delete oniguruma build files is sufficiently met later in the Dockerfile, by the already-existing ` rm -rf oniguruma-5.9.6` command.