### PR TITLE
Mingw64 fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ AM_YFLAGS = --warnings=all -d
 lib_LTLIBRARIES = libjq.la
 libjq_la_SOURCES = ${LIBJQ_SRC}
 libjq_la_LIBADD = -lm
-libjq_la_LDFLAGS = $(onig_LDFLAGS) -export-symbols-regex '^j[qv]_' -version-info 1:4:0
+libjq_la_LDFLAGS = $(onig_LDFLAGS) -export-symbols-regex '^j[qv]_' -version-info 1:4:0 -no-undefined
 
 if WIN32
 libjq_la_LIBADD += -lshlwapi

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ m4_include([m4/ax_compare_version.m4])
 m4_include([m4/ax_prog_bison_version.m4])
 
 dnl Created autoconf implementation thompson@dtosolutions, 26NOV12
+AX_CHECK_ENABLE_DEBUG()
 AC_PREREQ([2.64])
 AC_CONFIG_AUX_DIR([config])
 AM_INIT_AUTOMAKE([1.11.2 subdir-objects parallel-tests foreign -Wall])

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1196,6 +1196,8 @@ static jv tm2jv(struct tm *tm) {
 static time_t my_timegm(struct tm *tm) {
 #ifdef HAVE_TIMEGM
   return timegm(tm);
+#elif _WIN32
+  return _mkgmtime(tm);
 #else /* HAVE_TIMEGM */
   char *tz;
 


### PR DESCRIPTION
Hi,

the current Windows exe for jq 1.5 has a bug. `sort` or `uniq` take forever probably because of quadratic behavior. I tried compiling the git verion on mingw64 and had to fix some problems.

1. Building DLLs failed with
```
libtool: warning: undefined symbols not allowed in x86_64-w64-mingw32 shared libraries; building static only
```
2. Linking the exe failed with
```
./.libs/libjq.a(builtin.o): In function `my_timegm':
C:\src\jq/src/builtin.c:1204: undefined reference to `setenv'
C:\src\jq/src/builtin.c:1207: undefined reference to `setenv'
collect2.exe: error: ld returned 1 exit status
```

I fixed the problems and the resulting exe fixed the problem with `sort` and `uniq`. I only tested the 64-bit build.