### PR TITLE
Use rvm to install ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_install:
     - brew update               || true;
       brew install flex         || true;
       brew install bison        || true;
+    - rvm install ruby-1.9.3-p551
+    - rvm use 1.9.3
     - rm src/{lexer,parser}.{c,h}
     - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac
 


### PR DESCRIPTION
Update the Travis CI config to install and use the version of ruby supported by the docs, allowing the dependencies to install successfully

It seems the build still fails after this fix, that seems to be due to actual test failures