### PR TITLE
Keep object keys in parsing order in `tostream` output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ David R. MacIver     <david@drmaciver.com>            - bug fixes
 David Tolnay         <dtolnay@gmail.com>              - destructuring, build improvements
 Doug Luce            <doug@github.con.com>            - build
 Eiichi Sato          <sato.eiichi@gmail.com>
+Eric Bréchemier      <eric@egull.co>                  - bug fix
 Filippo Giunchedi    <fgiunchedi@gmail.com>           - bug fixes
 Filippo Valsorda     <filippo.valsorda@gmail.com>     - recursive object merge (`*`)
 Hanfei Shen          <qqshfox@gmail.com>

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -237,7 +237,7 @@ def tostream:
   else
     # We really need a _streaming_ form of `keys`.
     # We can use `range` for arrays, but not for objects.
-    keys as $keys |
+    keys_unsorted as $keys |
     $keys[-1] as $last|
     ((# for each key
       $keys[] | . as $key |


### PR DESCRIPTION
As noted by @nicowilliams, `tostream` used `keys`, which sorts the keys in alphabetical order, instead of `keys_unsorted`, which preserves the parsing order.

After the change, the behavior of `tostream` matches the behavior of `--stream`:

```
$ echo '{"a":"one","B":"two"}' | ./jq '. | tostream'
[
  [
    "a"
  ],
  "one"
]
[
  [
    "B"
  ],
  "two"
]
[
  [
    "B"
  ]
]
```

matches

```
 $ echo '{"a":"one","B":"two"}' | ./jq --stream '.'
[
  [
    "a"
  ],
  "one"
]
[
  [
    "B"
  ],
  "two"
]
[
  [
    "B"
  ]
]
```

which fixes #1541.