### PR TITLE
Build and deploy to GH statically linked binaries for various arches and test against musl libc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,34 @@ jobs:
         -   <<: *test-osx
             compiler: clang
 
+
+        # Build with gcc and run tests on Alpine Linux v3.7 (inside chroot).
+        # Note: Alpine uses musl libc.
+        -   &test-alpine
+            stage: test
+            os: linux
+            language: minimal
+            compiler: gcc
+            sudo: true
+
+            before_install:
+                - "wget 'https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.7.0/alpine-chroot-install' \
+                    && echo '090d323d887ef3a2fd4e752428553f22a52b87bb  alpine-chroot-install' | sha1sum -c || travis_terminate 1"
+                - alpine() { /alpine/enter-chroot -u "$USER" "$@"; }
+
+            install:
+                - sudo sh alpine-chroot-install -b v3.7 -a "$ARCH"
+                    -p 'build-base automake autoconf bison libtool oniguruma-dev'
+
+            before_script:
+                - autoreconf -if
+
+            script:
+                - alpine ./configure --disable-docs
+                - alpine make
+                - alpine make check
+
+
 notifications:
     email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,93 +1,115 @@
-os:
-    - linux
-    - osx
-
 sudo: false
 
 language: c
 
-compiler:
-    - gcc
-    - clang
-
-matrix:
+jobs:
     include:
-        - compiler: gcc
-          env: COVERAGE="--disable-valgrind --enable-gcov"
-          os: linux
+        # Build with gcc and run tests on Ubuntu.
+        -   &test-ubuntu
+            stage: test
+            os: linux
+            compiler: gcc
 
-addons:
-    apt:
-        packages:
-            - valgrind
-            - bison
-            - automake
+            addons:
+                apt:
+                    packages:
+                        - valgrind
+                        - bison
+                        - automake
 
-before_install:
-    - echo "$TRAVIS_OS_NAME"
-    - uname -s
-    - brew update               || true;
-      brew install flex         || true;
-      brew install bison        || true;
-    - rvm install ruby-1.9.3-p551
-    - rvm use 1.9.3
-    - rm src/{lexer,parser}.{c,h}
-    - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac
+            before_install:
+                - uname -s
+                - rvm install ruby-1.9.3-p551
+                - rvm use 1.9.3
+                - rm src/{lexer,parser}.{c,h}
+                - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac
 
-install:
-    - bundle install --gemfile=docs/Gemfile
-    - wget http://ftp.debian.org/debian/pool/main/b/bison/bison_3.0.2.dfsg-2_amd64.deb
-    - ar p bison_3.0.2.dfsg-2_amd64.deb data.tar.xz | tar xJ
-    - if [ -n "$COVERAGE" ]; then pip install --user cpp-coveralls; fi
+            install:
+                - bundle install --gemfile=docs/Gemfile
+                - wget http://ftp.debian.org/debian/pool/main/b/bison/bison_3.0.2.dfsg-2_amd64.deb
+                - ar p bison_3.0.2.dfsg-2_amd64.deb data.tar.xz | tar xJ
+                - if [ -n "$COVERAGE" ]; then pip install --user cpp-coveralls; fi
 
-before_script:
-    # If this is OS X we'll get bison from brew, else we'll get bison
-    # from the .deb unpacked above in the install section.
-    - PATH=/usr/local/opt/bison/bin:$PWD/usr/bin:$PATH
-    - echo SHELL=$SHELL
-    - echo PATH=$PATH
-    - which bison
-    - bison --version
-    - autoreconf -if
-    - ./configure --with-oniguruma=builtin YACC="$(which bison) -y" $COVERAGE
+            before_script:
+                # If this is OS X we'll get bison from brew, else we'll get bison
+                # from the .deb unpacked above in the install section.
+                - PATH=/usr/local/opt/bison/bin:$PWD/usr/bin:$PATH
+                - echo SHELL=$SHELL
+                - echo PATH=$PATH
+                - which bison
+                - bison --version
+                - autoreconf -if
+                - ./configure --with-oniguruma=builtin YACC="$(which bison) -y" $COVERAGE
 
-script:
-    # When using the bison from Debian we need to tell that bison where
-    # to find its data.  Yay non-relocatable code.  Not.
-    - echo PATH=$PATH
-    - which bison
-    - make BISON_PKGDATADIR=$PWD/usr/share/bison src/parser.c || make src/parser.c
-    # Make dist!
-    #
-    # Make it first to fail the build early, before we test with
-    # valgrind.
-    - make dist
-    # Build and test the dist (without valgrind)
-    - |
-        (
-          tar xvf jq-`scripts/version`.tar.gz &&
-          cd jq-`scripts/version` &&
-          pwd &&
-          ./configure --disable-valgrind --with-oniguruma=builtin YACC="$(which bison) -y" $COVERAGE &&
-          make BISON_PKGDATADIR=$PWD/usr/share/bison src/parser.c || make src/parser.c &&
-          make -j4 &&
-          make check -j4 || true
-        )
-    # Build and test the HEAD
-    - make -j4
-    - make check -j4
+            script:
+                # When using the bison from Debian we need to tell that bison where
+                # to find its data.  Yay non-relocatable code.  Not.
+                - echo PATH=$PATH
+                - which bison
+                - make BISON_PKGDATADIR=$PWD/usr/share/bison src/parser.c || make src/parser.c
+                # Make dist!
+                #
+                # Make it first to fail the build early, before we test with
+                # valgrind.
+                - make dist
+                # Build and test the dist (without valgrind)
+                - |
+                    (
+                    tar xvf jq-`scripts/version`.tar.gz &&
+                    cd jq-`scripts/version` &&
+                    pwd &&
+                    ./configure --disable-valgrind --with-oniguruma=builtin YACC="$(which bison) -y" $COVERAGE &&
+                    make BISON_PKGDATADIR=$PWD/usr/share/bison src/parser.c || make src/parser.c &&
+                    make -j4 &&
+                    make check -j4 || true
+                    )
+                # Build and test the HEAD
+                - make -j4
+                - make check -j4
 
-after_script:
-    - |
-        if [ -n "$COVERAGE" ]; then
-            rm -rf src/.libs # don't care about coverage for libjq
-            coveralls --gcov-options '\-lp' \
-                -e src/lexer.c -e src/parser.c -e src/jv_dtoa.c
-        fi
+            after_failure:
+                - cat test-suite.log
+                - cat tests/*.log
 
-after_failure:
-    - cat test-suite.log
-    - cat tests/*.log
+
+        # Build with clang and run tests on Ubuntu.
+        -   <<: *test-ubuntu
+            compiler: clang
+
+
+        # Build with gcc and run tests with gcov on Ubuntu.
+        -   <<: *test-ubuntu
+            env: COVERAGE="--disable-valgrind --enable-gcov"
+
+            after_script:
+                - rm -rf src/.libs # don't care about coverage for libjq
+                - coveralls --gcov-options '\-lp'
+                    -e src/lexer.c -e src/parser.c -e src/jv_dtoa.c
+
+
+        # Build with gcc and run tests on macOS.
+        -   &test-osx
+            <<: *test-ubuntu
+            os: osx
+
+            before_install:
+                - uname -s
+                - brew update
+                - brew install flex
+                - brew install bison
+                - rvm install ruby-1.9.3-p551
+                - rvm use 1.9.3
+                - rm src/{lexer,parser}.{c,h}
+                - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac
+
+            install:
+                - bundle install --gemfile=docs/Gemfile
+                - if [ -n "$COVERAGE" ]; then pip install --user cpp-coveralls; fi
+
+
+        # Build with clang and run tests on macOS.
+        -   <<: *test-osx
+            compiler: clang
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ sudo: false
 
 language: c
 
+stages:
+    -   name: test
+
+    -   name: build
+        # Don't run build stage for pull requests to save time and resources.
+        if: type != pull_request
+
+
 jobs:
     include:
         # Build with gcc and run tests on Ubuntu.
@@ -137,6 +145,56 @@ jobs:
                 - alpine ./configure --disable-docs
                 - alpine make
                 - alpine make check
+
+
+        # Build release binary statically linked with musl libc on Alpine Linux
+        # (inside chroot). If building a tagged commit, then deploy release
+        # tarball to GitHub Releases.
+        -   &build-alpine
+            <<: *test-alpine
+            stage: build
+            env: ARCH=x86_64
+
+            script:
+                - alpine ./configure --disable-docs --enable-all-static
+                    CFLAGS='-Os -static -no-pie' CXXFLAGS='-Os -static -no-pie'
+                - alpine make
+                - alpine strip jq
+
+                - jq -V
+                - ls -lah jq
+                - file jq
+                # Ensure that the built executable is really statically linked.
+                - file jq | grep -Fw 'statically linked'
+
+            before_deploy:
+                - PKGNAME="jq-$TRAVIS_TAG-$ARCH-linux"
+                - mkdir $PKGNAME && mv jq $PKGNAME/
+                - tar -czf $PKGNAME.tar.gz $PKGNAME/
+                - sha256sum $PKGNAME.tar.gz > $PKGNAME.tar.gz.sha256
+
+            deploy:
+                provider: releases
+                api_key:
+                    secure:  # TODO: put encrypted GitHub token here!
+                file: jq-$TRAVIS_TAG-*.tar.gz*
+                file_glob: true
+                skip_cleanup: true
+                on:
+                    tags: true
+
+        # Build binaries for other architectures using QEMU user-mode emulation.
+        -   <<: *build-alpine
+            env: ARCH=x86
+
+        -   <<: *build-alpine
+            env: ARCH=aarch64
+
+        -   <<: *build-alpine
+            env: ARCH=armhf
+
+        -   <<: *build-alpine
+            env: ARCH=ppc64le
 
 
 notifications:


### PR DESCRIPTION
1. Refactored `.travis.yml` to use Travis [Build Stages](https://docs.travis-ci.com/user/build-stages/) (this allows to define jobs with completely different configuration).
2. Added job that builds and tests jq with gcc 6.4 on Alpine Linux v3.7 (inside chroot), i.e. verifies that it works with musl libc.
3. Added jobs that build fully statically linked (with musl libc) jq on Alpine Linux v3.7 aarch64, armhf, and ppc64le architectures emulated using QEMU user-mode emulator and binfmt. Emulation is quite slow, so it takes more time to build.
4. **Configured automatic deployment of statically linked jq built for x86_64, x86, aarch64, armhf, and ppc64le to GitHub Releases.**

You just need to replace `secret:  # TODO…` with your **encrypted** [personal GitHub token](https://github.com/settings/tokens) (use gem [travis](https://rubygems.org/gems/travis) to encrypt it: `travis encrypt YOUR_TOKEN`). I recommend to create a separate GitHub account for this, because personal access tokens have too wide scope. Unfortunately Travis does not support any better authentication method for deployment to GitHub Releases.

Once you set up it and tag new release, Travis should automatically build and deploy a tar.gz archive with statically linked binaries for each architecture into Releases (it looks like [this](https://github.com/alpinelinux/apk-tools/releases)).