### PR TITLE
src/main.c: fix issue #1587 by using jv_dumpf in the raw-output and a…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -167,7 +167,11 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
   jv result;
   while (jv_is_valid(result = jq_next(jq))) {
     if ((options & RAW_OUTPUT) && jv_get_kind(result) == JV_KIND_STRING) {
-      fwrite(jv_string_value(result), 1, jv_string_length_bytes(jv_copy(result)), stdout);
+      if (options & ASCII_OUTPUT) {
+        jv_dumpf(result, stdout, JV_PRINT_ASCII);
+      } else {
+        fwrite(jv_string_value(result), 1, jv_string_length_bytes(jv_copy(result)), stdout);
+      }
       ret = 0;
       jv_free(result);
     } else {


### PR DESCRIPTION
…scii-output case. retain fwrite in the raw-output case.