### PR TITLE
doc note on reduction update outputting empty (#1612)

### DIFF
--- a/docs/content/2.download/default.yml
+++ b/docs/content/2.download/default.yml
@@ -66,12 +66,12 @@ body:
 
       ### FreeBSD
 
-	 * `pkg install jq` as root installs a pre-built
-	   [binary package](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/pkgng-intro.html).
-	 * `make -C /usr/ports/textproc/jq install clean` as root installs the
-	   [jq](https://www.freshports.org/textproc/jq/)
-	   [port](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports-using.html)
-	   from source.
+       * `pkg install jq` as root installs a pre-built
+         [binary package](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/pkgng-intro.html).
+       * `make -C /usr/ports/textproc/jq install clean` as root installs the
+         [jq](https://www.freshports.org/textproc/jq/)
+         [port](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports-using.html)
+         from source.
 
       ### Solaris
 

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -2603,10 +2603,19 @@ sections:
                   (2 as $item | . + $item) |
                   (1 as $item | . + $item)
 
+          Note that if any reduction iteration outputs `empty`, the
+          result being accumulated will be reset to null.
+
         examples:
           - program: 'reduce .[] as $item (0; . + $item)'
             input: '[10,2,5,3]'
             output: ['20']
+          - program: 'reduce .[] as $n ([]; if $n%2==0 then . else . + [$n] end)'
+            input: '[0,1,2,3,4,5]'
+            output: ['[1,3,5]']
+          - program: 'reduce .[] as $x (10; if ($x == 2) then empty else . + $x end)'
+            input: '[1,2,4]'
+            output: ['4']
 
       - title: "`isempty(exp)`"
         body: |
@@ -2976,7 +2985,10 @@ sections:
           .foo |= . + 1` instead.
 
           If the right-hand side outputs no values (i.e., `empty`), then
-          the left-hand side path will be deleted, as with `del(path)`.
+          the left-hand side path will be deleted, as with `del(path)`
+          (COMPATIBILITY NOTE: in jq 1.5 and earlier releases, the entire
+          jq output used to be set to `null` when the ride-hand side would
+          output no values).
 
           If the right-hand side outputs multiple values, only the first
           one will be used (COMPATIBILITY NOTE: in jq 1.5 and earlier


### PR DESCRIPTION
This reintroduces a modified version of the reduction example that @nicowilliams removed a while back and adds another example showing what happens when a reduction iteration returns `empty`.

I also converted some tabs to spaces that were causing `rake build` to fail.

The last change here is a "compatibility note" regarding the use of `|= empty`. Based on the following commands, it looks like 1.5 outputs null if `|= empty` appears anywhere in the program, but the latest source build behaves like described in the manual.

Let me know how it looks.

```
bnran at dca90496b22a in ~/dev/jq on master*
$ echo "{\"foo\":{\"bar\":{\"baz\":123,\"qux\":\"corge\"}}}" | jq '.foo.bar.baz |= empty'
{
  "foo": {
    "bar": {
      "qux": "corge"
    }
  }
}
bnran at dca90496b22a in ~/dev/jq on master*
$ echo "{\"foo\":{\"bar\":{\"baz\":123,\"qux\":\"corge\"}}}" | jq '.foo.bar |= empty'
{
  "foo": {}
}
bnran at dca90496b22a in ~/dev/jq on master*
$ echo "{\"foo\":{\"bar\":{\"baz\":123,\"qux\":\"corge\"}}}" | jq '.foo |= empty'
{}
bnran at dca90496b22a in ~/dev/jq on master*
$ jq -n '{a:1,b:1} | .a |= empty'
{
  "b": 1
}
bnran at dca90496b22a in ~/dev/jq on master*
$ which jq
./jq
bnran at dca90496b22a in ~/dev/jq on master*
$ cd .. && which jq
/usr/local/bin/jq
bnran at dca90496b22a in ~/dev
$ jq -n '{a:1,b:1} | .a |= empty'
null
bnran at dca90496b22a in ~/dev
$ echo "{\"foo\":{\"bar\":{\"baz\":123,\"qux\":\"corge\"}}}" | jq '.foo |= empty'
null
bnran at dca90496b22a in ~/dev
$ echo "{\"foo\":{\"bar\":{\"baz\":123,\"qux\":\"corge\"}}}" | jq '.foo.bar |= empty'
null
bnran at dca90496b22a in ~/dev
$ echo "{\"foo\":{\"bar\":{\"baz\":123,\"qux\":\"corge\"}}}" | jq '.foo.bar.baz |= empty'
null
bnran at dca90496b22a in ~/dev
$ jq --version
jq-1.5
bnran at dca90496b22a in ~/dev
$ cd jq && jq --version
jq-1.6rc1-11-g88ea339-dirty
```
