### PR TITLE
Enhanced builtins all, any and range/3

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -32,20 +32,13 @@ def index($i):   indices($i) | .[0];       # TODO: optimize
 def rindex($i):  indices($i) | .[-1:][0];  # TODO: optimize
 def paths: path(recurse(if (type|. == "array" or . == "object") then .[] else empty end))|select(length > 0);
 def paths(node_filter): . as $dot|paths|select(. as $p|$dot|getpath($p)|node_filter);
-def any(generator; condition):
-        [label $out | foreach generator as $i
-                 (false;
-                  if . then break $out elif $i | condition then true else . end;
-                  if . then . else empty end)] | length == 1;
-def any(condition): any(.[]; condition);
-def any: any(.);
-def all(generator; condition):
-        [label $out | foreach generator as $i
-                 (true;
-                  if .|not then break $out elif $i | condition then . else false end;
-                  if .|not then . else empty end)] | length == 0;
-def all(condition): all(.[]; condition);
-def all: all(.);
+def isempty(g): 0 == ((label $go | g | (1, break $go)) // 0);
+def all(generator; condition): isempty(generator | condition and empty);
+def all: isempty(.[] and empty);
+def all(condition): isempty(.[] | condition and empty);
+def any(generator; condition): false==isempty(generator | condition or empty);
+def any: false==isempty(.[] or empty);
+def any(condition): false==isempty(.[] | condition or empty);
 def isfinite: type == "number" and (isinfinite | not);
 def arrays: select(type == "array");
 def objects: select(type == "object");
@@ -154,10 +147,12 @@ def gsub($re; s): sub($re; s; "g");
 
 ########################################################################
 # range/3, with a `by` expression argument
-def range($init; $upto; $by):
-    def _range:
-        if ($by > 0 and . < $upto) or ($by < 0 and . > $upto) then ., ((.+$by)|_range) else . end;
-    if $by == 0 then $init else $init|_range end | select(($by > 0 and . < $upto) or ($by < 0 and . > $upto));
+def range($init; $upto; $by): #:: (number;number;number) => *number
+    label $out
+    | ($by>0) as $inc | ($by<0) as $dec
+    | $init|recurse(.+$by)
+    | if $inc and . < $upto or $dec and . > $upto
+      then .  else break$out end;
 # generic iterator/generator
 def while(cond; update):
      def _while:
@@ -171,7 +166,6 @@ def limit($n; exp):
   if $n < 0 then exp
   else label $out | foreach exp as $item ($n; .-1; $item, if . <= 0 then break $out else empty end)
   end;
-def isempty(g): 0 == ((label $go | g | (1, break $go)) // 0);
 def first(g): label $out | g | ., break $out;
 def last(g): reduce g as $item (null; $item);
 def nth($n; g): if $n < 0 then error("nth doesn't support negative indices") else last(limit($n + 1; g)) end;


### PR DESCRIPTION
Changed definitions in builtin.jq for `all`, `any` and `range/3` for faster and clearer versions.

Moved `isempty` above in the file.