### PR TITLE
docs: --indent value has maximum of 7, not 8

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -153,7 +153,7 @@ sections:
 
       * `--indent n`:
 
-        Use the given number of spaces (no more than 8) for indentation.
+        Use the given number of spaces (no more than 7) for indentation.
 
       * `--color-output` / `-C` and `--monochrome-output` / `-M`:
 

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -152,7 +152,7 @@ sections:
 
       * `--indent n`:
 
-        Use the given number of spaces (no more than 8) for indentation.
+        Use the given number of spaces (no more than 7) for indentation.
 
       * `--color-output` / `-C` and `--monochrome-output` / `-M`:
 

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -152,7 +152,7 @@ sections:
 
       * `--indent n`:
 
-        Use the given number of spaces (no more than 8) for indentation.
+        Use the given number of spaces (no more than 7) for indentation.
 
       * `--color-output` / `-C` and `--monochrome-output` / `-M`:
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -97,7 +97,7 @@ Use a tab for each indentation level instead of two spaces\.
 \fB\-\-indent n\fR:
 .
 .IP
-Use the given number of spaces (no more than 8) for indentation\.
+Use the given number of spaces (no more than 7) for indentation\.
 .
 .IP "\(bu" 4
 \fB\-\-color\-output\fR / \fB\-C\fR and \fB\-\-monochrome\-output\fR / \fB\-M\fR:


### PR DESCRIPTION
Test Plan:
To verify that this is in fact the behavior:

```
$ jq --indent 7 -n '[1]'
[
       1
]
$ jq --indent 8 -n '[1]'
jq: --indent takes a number between -1 and 7
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://stedolan.github.io/jq
```

This patch was generated by running `git grep "no more than"` and fixing
up appropriate results.

wchargin-branch: docs-fix-indent-bounds