### PR TITLE
Light README edit: Improve formatting of flags and link to specific wiki article

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Cross-compilation requires a clean workspace, then:
     make distclean
     scripts/crosscompile <name-of-build> <configure-options>
 
-Use the --host= and --target= ./configure options to select a
-cross-compilation environment.  See also the wiki.
+Use the `--host=` and `--target=` ./configure options to select a
+cross-compilation environment.  See also 
+["Cross compilation"](https://github.com/stedolan/jq/wiki/Cross-compilation) on
+the wiki.
 
 Send questions to https://stackoverflow.com/questions/tagged/jq or to the #jq channel (http://irc.lc/freenode/%23jq/) on Freenode (https://webchat.freenode.net/).


### PR DESCRIPTION
I slightly edited the last paragraph about cross-compilation; I changed the flag formatting to be consistent with the rest of the document and added a link to the relevant wiki page.