### PR TITLE
Save literal value of the parsed number to preserve it for the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/*.trs
 cscope.in.out
 cscope.out
 cscope.po.out
+jq.dSYM

--- a/Makefile.am
+++ b/Makefile.am
@@ -170,7 +170,8 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         tests/modules/test_bind_order.jq                                \
         tests/modules/test_bind_order0.jq                               \
         tests/modules/test_bind_order1.jq                               \
-        tests/modules/test_bind_order2.jq tests/onig.supp               \
+        tests/modules/test_bind_order2.jq                               \
+        tests/onig.supp tests/local.supp                                \
         tests/onig.test tests/setup tests/torture/input0.json		\
         tests/optional.test tests/optionaltest				\
 	tests/utf8-truncate.jq tests/utf8test				\

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -292,10 +292,20 @@ sections:
           program can be a useful way of formatting JSON output from,
           say, `curl`.
 
+          An important point about the identity filter is that it 
+          guarantees to preserve the literal representation of values. 
+          This is particularly important when dealing with numbers 
+          which otherwise get truncated to an IEEE754 double precision 
+          representation.
+
         examples:
           - program: '.'
             input: '"Hello, world!"'
             output: ['"Hello, world!"']
+
+          - program: '. | tojson'
+            input: '12345678909876543212345'
+            output: ['"12345678909876543212345"']
 
       - title: "Object Identifier-Index: `.foo`, `.foo.bar`"
         body: |
@@ -511,6 +521,16 @@ sections:
       expression that takes an input, ignores it, and returns 42
       instead.
 
+      Numbers in jq are internally represented by their IEEE754 double 
+      precision approximation. Any arithmetic operation with numbers, 
+      whether they are literals or results of previous filters, will 
+      produce a double precision floating point result.
+
+      However, when parsing a literal jq will store the original literal
+      string. If no mutation is applied to this value then it will make
+      to the output in its original form, even if conversion to double 
+      would result in a loss. 
+
     entries:
       - title: "Array construction: `[]`"
         body: |
@@ -628,6 +648,18 @@ sections:
       etc.). However, jq never does implicit type conversions. If you
       try to add a string to an object you'll get an error message and
       no result.
+
+      Please note that all numbers are converted to IEEE754 double precision 
+      floating point representation. Arithmetic and logical operators are working
+      with these converted doubles. Results of all such operations are also limited 
+      to the double precision. 
+
+      The only exception to this behaviour of number is a snapshot of original number 
+      literal. When a number which originally was provided as a literal is never
+      mutated until the end of the program then it is printed to the output in its 
+      original literal form. This also includes cases when the original literal 
+      would be truncated when converted to the IEEE754 double precision floating point
+      number. See `literal` filter for more information on this topic.
 
     entries:
       - title: "Addition: `+`"
@@ -1233,6 +1265,36 @@ sections:
             input: '[1, "1", [1]]'
             output: ['"1"', '"1"', '"[1]"']
 
+      - title: "`literal`"
+        body: |
+
+          The `literal` function can be used to return the original literal
+          representation of a value as a string. This function can only be applied
+          to the simple types [string, null, false, true] and numbers which were provided
+          as literal constants. Calucated numbers don't have an associated literal, and will 
+          produce an error.
+
+          There is resemblence between this function and `tojson`, `tostring`. 
+          jq will preserve the original literal value of a number constant
+          in when converted to string via any of `literal`, `tostring`, `tojson`.
+          However, the `literal` varaint will provide type safety by returning an error
+          if applied to a computed number.
+
+          `fromjson` can be used to generate a literal number
+
+        examples: 
+          - program: '. as $big | [literal($big), ($big | tojson), ($big | tostring)] | map(.=="10000000000000000000000000000001")'
+            input: '10000000000000000000000000000001'
+            output: ['[true, true, true]']
+
+          - program: '(. + 1) as $big | (try literal($big) catch .), ($big | tojson), ($big | tostring)'
+            input: '10000000000000000000000000000001'
+            output: ['"literal value is not available for a calculated number"', '"1e+31"', '"1e+31"']
+
+          - program: 'literal(.) as $l | [$l, ($l | fromjson)] | tojson'
+            input: '10000000000000000000000000000001'
+            output: ['"[\"10000000000000000000000000000001\",10000000000000000000000000000001]"']
+         
       - title: "`type`"
         body: |
 
@@ -2018,12 +2080,10 @@ sections:
 
           != is "not equal", and 'a != b' returns the opposite value of 'a == b'
 
-          Numbers are now taken literally, so 1 != 1.0
-
         examples:
           - program: '.[] == 1'
             input: '[1, 1.0, "1", "banana"]'
-            output: ['true', 'false', 'false', 'false']
+            output: ['true', 'true', 'false', 'false']
 
       - title: if-then-else
         body: |

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -659,7 +659,7 @@ sections:
       mutated until the end of the program then it is printed to the output in its 
       original literal form. This also includes cases when the original literal 
       would be truncated when converted to the IEEE754 double precision floating point
-      number. See `literal` filter for more information on this topic.
+      number. See `toliteral` filter for more information on this topic.
 
     entries:
       - title: "Addition: `+`"
@@ -1265,10 +1265,10 @@ sections:
             input: '[1, "1", [1]]'
             output: ['"1"', '"1"', '"[1]"']
 
-      - title: "`literal`"
+      - title: "`toliteral`"
         body: |
 
-          The `literal` function can be used to return the original literal
+          The `toliteral` function can be used to return the original literal
           representation of a value as a string. This function can only be applied
           to the simple types [string, null, false, true] and numbers which were provided
           as literal constants. Calucated numbers don't have an associated literal, and will 
@@ -1276,25 +1276,33 @@ sections:
 
           There is resemblence between this function and `tojson`, `tostring`. 
           jq will preserve the original literal value of a number constant
-          in when converted to string via any of `literal`, `tostring`, `tojson`.
+          when converted to string via any of `literal`, `tostring`, `tojson`.
           However, the `literal` varaint will provide type safety by returning an error
           if applied to a computed number.
+
+          In practice, `toliteral` can be used as a typesefe version of `tojson`
+          Please note that for strings `toliteral` will produce a quoted JSON string,
+          while `tostring` will produce the string itelf. In this, `toliteral` works
+          like `tojson`
 
           `fromjson` can be used to generate a literal number
 
         examples: 
-          - program: '. as $big | [literal($big), ($big | tojson), ($big | tostring)] | map(.=="10000000000000000000000000000001")'
+          - program: '. as $big | [($big | toliteral), ($big | tojson), ($big | tostring)] | map(.=="10000000000000000000000000000001")'
             input: '10000000000000000000000000000001'
             output: ['[true, true, true]']
 
-          - program: '(. + 1) as $big | (try literal($big) catch .), ($big | tojson), ($big | tostring)'
+          - program: '(. + 1) as $big | (try ($big | toliteral) catch .), ($big | tojson), ($big | tostring)'
             input: '10000000000000000000000000000001'
             output: ['"literal value is not available for a calculated number"', '"1e+31"', '"1e+31"']
 
-          - program: 'literal(.) as $l | [$l, ($l | fromjson)] | tojson'
+          - program: '(. | toliteral) as $l | [$l, ($l | fromjson)] | tojson'
             input: '10000000000000000000000000000001'
             output: ['"[\"10000000000000000000000000000001\",10000000000000000000000000000001]"']
          
+          - program: '(. | toliteral) == (. | tojson)'
+            input: '"Hello literal"'
+            output: [true]
       - title: "`type`"
         body: |
 

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1272,20 +1272,22 @@ sections:
           representation of a value as a string. This function can only be applied
           to the simple types [string, null, false, true] and numbers which were provided
           as literal constants. Calucated numbers don't have an associated literal, and will 
-          produce an error.
+          produce an error. Trying to get a literal of NaN or infinity will produce 
+          an error as well.
 
           There is resemblence between this function and `tojson`, `tostring`. 
           jq will preserve the original literal value of a number constant
           when converted to string via any of `literal`, `tostring`, `tojson`.
-          However, the `literal` varaint will provide type safety by returning an error
-          if applied to a computed number.
+          However, the `literal` varaint will provide type safety by as per
+          the rules described above.
 
-          In practice, `toliteral` can be used as a typesefe version of `tojson`
           Please note that for strings `toliteral` will produce a quoted JSON string,
           while `tostring` will produce the string itelf. In this, `toliteral` works
           like `tojson`
 
-          `fromjson` can be used to generate a literal number
+          In practice, `toliteral` can be used as a typesefe version of `tojson`.
+          
+          `fromjson` can be used to generate a number from its literal representation.
 
         examples: 
           - program: '. as $big | [($big | toliteral), ($big | tojson), ($big | tostring)] | map(.=="10000000000000000000000000000001")'
@@ -1294,7 +1296,7 @@ sections:
 
           - program: '(. + 1) as $big | (try ($big | toliteral) catch .), ($big | tojson), ($big | tostring)'
             input: '10000000000000000000000000000001'
-            output: ['"literal value is not available for a calculated number"', '"1e+31"', '"1e+31"']
+            output: ['"literal value is not available for a calculated number, infinite number or a NaN"', '"1e+31"', '"1e+31"']
 
           - program: '(. | toliteral) as $l | [$l, ($l | fromjson)] | tojson'
             input: '10000000000000000000000000000001'

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -2018,10 +2018,12 @@ sections:
 
           != is "not equal", and 'a != b' returns the opposite value of 'a == b'
 
+          Numbers are now taken literally, so 1 != 1.0
+
         examples:
           - program: '.[] == 1'
             input: '[1, 1.0, "1", "banana"]'
-            output: ['true', 'true', 'false', 'false']
+            output: ['true', 'false', 'false', 'false']
 
       - title: if-then-else
         body: |

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -471,23 +471,21 @@ static jv f_tostring(jq_state *jq, jv input) {
   }
 }
 
-static jv f_literal(jq_state *jq, jv unused_input, jv a) {
-  jv_free(unused_input);
-  switch(jv_get_kind(a)) {
+static jv f_toliteral(jq_state *jq, jv input) {
+  switch(jv_get_kind(input)) {
     case JV_KIND_NUMBER:
-      if (!jv_is_literal_number(a)) {
-        return ret_error(a, jv_string("literal value is not available for a calculated number"));
+      if (!jv_is_literal_number(input)) {
+        return ret_error(input, jv_string("literal value is not available for a calculated number"));
       } else {
         // fallthrough!
       }
     case JV_KIND_NULL:
     case JV_KIND_TRUE:
     case JV_KIND_FALSE:
-      return jv_dump_string(a, 0);
     case JV_KIND_STRING:
-      return a;
+      return jv_dump_string(input, 0);
     default:
-      return type_error(a, "isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal");
+      return type_error(input, "isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal");
   }
 }
 
@@ -1631,7 +1629,7 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_json_parse, "fromjson", 1},
   {(cfunction_ptr)f_tonumber, "tonumber", 1},
   {(cfunction_ptr)f_tostring, "tostring", 1},
-  {(cfunction_ptr)f_literal, "literal", 2},
+  {(cfunction_ptr)f_toliteral, "toliteral", 1},
   {(cfunction_ptr)f_keys, "keys", 1},
   {(cfunction_ptr)f_keys_unsorted, "keys_unsorted", 1},
   {(cfunction_ptr)f_startswith, "startswith", 2},

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -474,7 +474,7 @@ static jv f_tostring(jq_state *jq, jv input) {
 static jv f_toliteral(jq_state *jq, jv input) {
   switch(jv_get_kind(input)) {
     case JV_KIND_NUMBER:
-      if (!jv_is_literal_number(input)) {
+      if (!jv_number_has_literal(input)) {
         return ret_error(input, jv_string("literal value is not available for a calculated number, infinite number or a NaN"));
       } else {
         // fallthrough!

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -471,6 +471,26 @@ static jv f_tostring(jq_state *jq, jv input) {
   }
 }
 
+static jv f_literal(jq_state *jq, jv unused_input, jv a) {
+  jv_free(unused_input);
+  switch(jv_get_kind(a)) {
+    case JV_KIND_NUMBER:
+      if (!jv_is_literal_number(a)) {
+        return ret_error(a, jv_string("literal value is not available for a calculated number"));
+      } else {
+        // fallthrough!
+      }
+    case JV_KIND_NULL:
+    case JV_KIND_TRUE:
+    case JV_KIND_FALSE:
+      return jv_dump_string(a, 0);
+    case JV_KIND_STRING:
+      return a;
+    default:
+      return type_error(a, "isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal");
+  }
+}
+
 static jv f_utf8bytelength(jq_state *jq, jv input) {
   if (jv_get_kind(input) != JV_KIND_STRING)
     return type_error(input, "only strings have UTF-8 byte length");
@@ -1611,6 +1631,7 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_json_parse, "fromjson", 1},
   {(cfunction_ptr)f_tonumber, "tonumber", 1},
   {(cfunction_ptr)f_tostring, "tostring", 1},
+  {(cfunction_ptr)f_literal, "literal", 2},
   {(cfunction_ptr)f_keys, "keys", 1},
   {(cfunction_ptr)f_keys_unsorted, "keys_unsorted", 1},
   {(cfunction_ptr)f_startswith, "startswith", 2},

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -87,8 +87,11 @@ static jv f_plus(jq_state *jq, jv input, jv a, jv b) {
     jv_free(b);
     return a;
   } else if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
-    return jv_number(jv_number_value(a) +
+    jv r = jv_number(jv_number_value(a) +
                      jv_number_value(b));
+    jv_free(a);
+    jv_free(b);
+    return r;
   } else if (jv_get_kind(a) == JV_KIND_STRING && jv_get_kind(b) == JV_KIND_STRING) {
     return jv_string_concat(a, b);
   } else if (jv_get_kind(a) == JV_KIND_ARRAY && jv_get_kind(b) == JV_KIND_ARRAY) {
@@ -271,7 +274,10 @@ static jv f_rtrimstr(jq_state *jq, jv input, jv right) {
 static jv f_minus(jq_state *jq, jv input, jv a, jv b) {
   jv_free(input);
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
-    return jv_number(jv_number_value(a) - jv_number_value(b));
+    jv r = jv_number(jv_number_value(a) - jv_number_value(b));
+    jv_free(a);
+    jv_free(b);
+    return r;
   } else if (jv_get_kind(a) == JV_KIND_ARRAY && jv_get_kind(b) == JV_KIND_ARRAY) {
     jv out = jv_array();
     jv_array_foreach(a, i, x) {
@@ -299,7 +305,10 @@ static jv f_multiply(jq_state *jq, jv input, jv a, jv b) {
   jv_kind bk = jv_get_kind(b);
   jv_free(input);
   if (ak == JV_KIND_NUMBER && bk == JV_KIND_NUMBER) {
-    return jv_number(jv_number_value(a) * jv_number_value(b));
+    jv r = jv_number(jv_number_value(a) * jv_number_value(b));
+    jv_free(a);
+    jv_free(b);
+    return r;
   } else if ((ak == JV_KIND_STRING && bk == JV_KIND_NUMBER) ||
              (ak == JV_KIND_NUMBER && bk == JV_KIND_STRING)) {
     jv str = a;
@@ -333,7 +342,10 @@ static jv f_divide(jq_state *jq, jv input, jv a, jv b) {
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
     if (jv_number_value(b) == 0.0)
       return type_error2(a, b, "cannot be divided because the divisor is zero");
-    return jv_number(jv_number_value(a) / jv_number_value(b));
+    jv r = jv_number(jv_number_value(a) / jv_number_value(b));
+    jv_free(a);
+    jv_free(b);
+    return r;
   } else if (jv_get_kind(a) == JV_KIND_STRING && jv_get_kind(b) == JV_KIND_STRING) {
     return jv_string_split(a, b);
   } else {
@@ -346,7 +358,10 @@ static jv f_mod(jq_state *jq, jv input, jv a, jv b) {
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
     if ((intmax_t)jv_number_value(b) == 0)
       return type_error2(a, b, "cannot be divided (remainder) because the divisor is zero");
-    return jv_number((intmax_t)jv_number_value(a) % (intmax_t)jv_number_value(b));
+    jv r = jv_number((intmax_t)jv_number_value(a) % (intmax_t)jv_number_value(b));
+    jv_free(a);
+    jv_free(b);
+    return r;
   } else {
     return type_error2(a, b, "cannot be divided (remainder)");
   }
@@ -437,7 +452,9 @@ static jv f_length(jq_state *jq, jv input) {
   } else if (jv_get_kind(input) == JV_KIND_STRING) {
     return jv_number(jv_string_length_codepoints(input));
   } else if (jv_get_kind(input) == JV_KIND_NUMBER) {
-    return jv_number(fabs(jv_number_value(input)));
+    jv r = jv_number(fabs(jv_number_value(input)));
+    jv_free(input);
+    return r;
   } else if (jv_get_kind(input) == JV_KIND_NULL) {
     jv_free(input);
     return jv_number(0);

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -475,7 +475,7 @@ static jv f_toliteral(jq_state *jq, jv input) {
   switch(jv_get_kind(input)) {
     case JV_KIND_NUMBER:
       if (!jv_is_literal_number(input)) {
-        return ret_error(input, jv_string("literal value is not available for a calculated number"));
+        return ret_error(input, jv_string("literal value is not available for a calculated number, infinite number or a NaN"));
       } else {
         // fallthrough!
       }

--- a/src/execute.c
+++ b/src/execute.c
@@ -1014,6 +1014,9 @@ jq_state *jq_init(void) {
   jq->attrs = jv_object();
   jq->path = jv_null();
   jq->value_at_path = jv_null();
+
+  jq->nomem_handler = NULL;
+  jq->nomem_handler_data = NULL;
   return jq;
 }
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -515,15 +515,16 @@ jv jq_next(jq_state *jq) {
         set_error(jq, jv_invalid_with_msg(jv_string_fmt("Range bounds must be numeric")));
         jv_free(max);
         goto do_backtrack;
-      } else if (jv_number_value(jv_copy(*var)) >= jv_number_value(jv_copy(max))) {
+      } else if (jv_number_value(*var) >= jv_number_value(max)) {
         /* finished iterating */
+        jv_free(max);
         goto do_backtrack;
       } else {
-        jv curr = jv_copy(*var);
+        jv curr = *var;
         *var = jv_number(jv_number_value(*var) + 1);
 
         struct stack_pos spos = stack_get_pos(jq);
-        stack_push(jq, jv_copy(max));
+        stack_push(jq, max);
         stack_save(jq, pc - 3, spos);
 
         stack_push(jq, curr);

--- a/src/execute.c
+++ b/src/execute.c
@@ -509,7 +509,10 @@ jv jq_next(jq_state *jq) {
       uint16_t v = *pc++;
       jv* var = frame_local_var(jq, v, level);
       jv max = stack_pop(jq);
-      if (raising) goto do_backtrack;
+      if (raising) {
+        jv_free(max);
+        goto do_backtrack;
+      } 
       if (jv_get_kind(*var) != JV_KIND_NUMBER ||
           jv_get_kind(max) != JV_KIND_NUMBER) {
         set_error(jq, jv_invalid_with_msg(jv_string_fmt("Range bounds must be numeric")));

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -105,6 +105,9 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int
         if (buf[0] == '\n' || (buf[0] == '\r' && buf[1] == '\n'))
           break;
       }
+      
+      must_fail = 0;
+      check_msg = 0;
 
       continue;
     } else if (skip == 0) {

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -6,20 +6,32 @@
 #include "jq.h"
 
 static void jv_test();
-static void run_jq_tests(jv, int, FILE *);
+static void run_jq_tests(jv, int, FILE *, int, int);
 
 
 int jq_testsuite(jv libdirs, int verbose, int argc, char* argv[]) {
   FILE *testdata = stdin;
+  int skip = -1;
+  int take = -1;
   jv_test();
   if (argc > 0) {
-    testdata = fopen(argv[0], "r");
-    if (!testdata) {
-      perror("fopen");
-      exit(1);
+    for(int i = 0; i < argc; i++) {
+      if (!strcmp(argv[i], "--skip")) {
+        skip = atoi(argv[i+1]);
+        i++;
+      } else if (!strcmp(argv[i], "--take")) {
+        take = atoi(argv[i+1]);
+        i++;
+      } else {
+        testdata = fopen(argv[i], "r");
+        if (!testdata) {
+          perror("fopen");
+          exit(1);
+        }
+      }
     }
   }
-  run_jq_tests(libdirs, verbose, testdata);
+  run_jq_tests(libdirs, verbose, testdata, skip, take);
   return 0;
 }
 
@@ -53,7 +65,7 @@ static void test_err_cb(void *data, jv e) {
   jv_free(e);
 }
 
-static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata) {
+static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int take) {
   char prog[4096];
   char buf[4096];
   struct err_data err_msg;
@@ -62,6 +74,9 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata) {
   int must_fail = 0;
   int check_msg = 0;
   jq_state *jq = NULL;
+
+  int tests_to_skip = skip;
+  int tests_to_take = take;
 
   jq = jq_init();
   assert(jq);
@@ -80,6 +95,31 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata) {
       continue;
     }
     if (prog[strlen(prog)-1] == '\n') prog[strlen(prog)-1] = 0;
+
+    if (skip > 0) {
+      skip--;
+
+      // skip past test data
+      while (fgets(buf, sizeof(buf), testdata)) {
+        lineno++;
+        if (buf[0] == '\n' || (buf[0] == '\r' && buf[1] == '\n'))
+          break;
+      }
+
+      continue;
+    } else if (skip == 0) {
+      printf("Skipped %d tests\n", tests_to_skip);
+      skip = -1;
+    }
+
+    if (take > 0) {
+      take--;
+    } else if (take == 0) {
+      printf("Hit the number of tests limit (%d), breaking\n", tests_to_take);
+      take = -1;
+      break;
+    }
+
     printf("Testing '%s' at line number %u\n", prog, lineno);
     int pass = 1;
     tests++;
@@ -179,7 +219,21 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata) {
     passed+=pass;
   }
   jq_teardown(&jq);
-  printf("%d of %d tests passed (%d malformed)\n", passed,tests,invalid);
+
+  int total_skipped = tests_to_skip > 0 ? tests_to_skip : 0;
+
+  if (skip > 0) {
+    total_skipped = tests_to_skip - skip;
+  }
+
+  printf("%d of %d tests passed (%d malformed, %d skipped)\n", 
+    passed, tests, invalid, total_skipped);
+
+  if (skip > 0) {
+    printf("WARN: skipped past the end of file, exiting with status 2\n");
+    exit(2);
+  }
+
   if (passed != tests) exit(1);
 }
 

--- a/src/jv.c
+++ b/src/jv.c
@@ -1401,11 +1401,7 @@ int jv_equal(jv a, jv b) {
   if (jv_get_kind(a) != jv_get_kind(b)) {
     r = 0;
   } else if (jv_get_kind(a) == JV_KIND_NUMBER) {
-    if (JVP_HAS_FLAGS(a, JVP_FLAGS_NUMBER_L) && JVP_HAS_FLAGS(b, JVP_FLAGS_NUMBER_L)) {
-      r = jvp_literal_number_equal(a, b);
-    } else {
-      r = jv_number_value(a) == jv_number_value(b);
-    }
+    r = jv_number_value(a) == jv_number_value(b);
   } else if (a.kind_flags == b.kind_flags &&
              a.size == b.size &&
              a.u.ptr == b.u.ptr) {
@@ -1448,7 +1444,9 @@ int jv_identical(jv a, jv b) {
       if (JVP_HAS_FLAGS(a, JVP_FLAGS_NUMBER_L) && JVP_HAS_FLAGS(b, JVP_FLAGS_NUMBER_L)) {
         r = a.u.ptr == b.u.ptr;
       } else {
-        r = memcmp(&a.u.number, &b.u.number, sizeof(a.u.number)) == 0;
+        double an = jv_number_value(a);
+        double bn = jv_number_value(b);
+        r = memcmp(&an, &bn, sizeof(double)) == 0;
       }
       break;
     default:

--- a/src/jv.c
+++ b/src/jv.c
@@ -521,14 +521,13 @@ jv jv_array_indexes(jv a, jv b) {
   jv res = jv_array();
   int idx = -1;
   jv_array_foreach(a, ai, aelem) {
+    jv_free(aelem);
     jv_array_foreach(b, bi, belem) {
-      // quieten compiler warnings about aelem not being used... by
-      // using it
-      if ((bi == 0 && !jv_equal(jv_copy(aelem), jv_copy(belem))) ||
-          (bi > 0 && !jv_equal(jv_array_get(jv_copy(a), ai + bi), jv_copy(belem))))
+      if (!jv_equal(jv_array_get(jv_copy(a), ai + bi), jv_copy(belem)))
         idx = -1;
       else if (bi == 0 && idx == -1)
         idx = ai;
+      jv_free(belem);
     }
     if (idx > -1)
       res = jv_array_append(res, jv_number(idx));
@@ -841,6 +840,7 @@ jv jv_string_implode(jv j) {
     jv n = jv_array_get(jv_copy(j), i);
     assert(JVP_HAS_KIND(n, JV_KIND_NUMBER));
     int nv = jv_number_value(n);
+    jv_free(n);
     if (nv > 0x10FFFF)
       nv = 0xFFFD; // U+FFFD REPLACEMENT CHARACTER
     s = jv_string_append_codepoint(s, nv);

--- a/src/jv.c
+++ b/src/jv.c
@@ -137,7 +137,7 @@ jv jv_invalid() {
 }
 
 jv jv_invalid_get_msg(jv inv) {
-  assert(jv_get_kind(inv) == JV_KIND_INVALID);
+  assert(JVP_HAS_KIND(inv, JV_KIND_INVALID));
 
   jv x;
   if (JVP_HAS_FLAGS(inv, JVP_FLAGS_INVALID_MSG)) {
@@ -292,7 +292,7 @@ typedef struct {
 } jvp_array;
 
 static jvp_array* jvp_array_ptr(jv a) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   return (jvp_array*)a.u.ptr;
 }
 
@@ -310,7 +310,7 @@ static jv jvp_array_new(unsigned size) {
 }
 
 static void jvp_array_free(jv a) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   if (jvp_refcnt_dec(a.u.ptr)) {
     jvp_array* array = jvp_array_ptr(a);
     for (int i=0; i<array->length; i++) {
@@ -321,17 +321,17 @@ static void jvp_array_free(jv a) {
 }
 
 static int jvp_array_length(jv a) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   return a.size;
 }
 
 static int jvp_array_offset(jv a) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   return a.offset;
 }
 
 static jv* jvp_array_read(jv a, int i) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   if (i >= 0 && i < jvp_array_length(a)) {
     jvp_array* array = jvp_array_ptr(a);
     assert(i + jvp_array_offset(a) < array->length);
@@ -400,7 +400,7 @@ static void jvp_clamp_slice_params(int len, int *pstart, int *pend)
 }
 
 static jv jvp_array_slice(jv a, int start, int end) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   int len = jvp_array_length(a);
   jvp_clamp_slice_params(len, &start, &end);
   assert(0 <= start && start <= end && end <= len);
@@ -437,14 +437,14 @@ jv jv_array() {
 }
 
 int jv_array_length(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(j, JV_KIND_ARRAY));
   int len = jvp_array_length(j);
   jv_free(j);
   return len;
 }
 
 jv jv_array_get(jv j, int idx) {
-  assert(jv_get_kind(j) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(j, JV_KIND_ARRAY));
   jv* slot = jvp_array_read(j, idx);
   jv val;
   if (slot) {
@@ -457,7 +457,7 @@ jv jv_array_get(jv j, int idx) {
 }
 
 jv jv_array_set(jv j, int idx, jv val) {
-  assert(jv_get_kind(j) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(j, JV_KIND_ARRAY));
 
   if (idx < 0)
     idx = jvp_array_length(j) + idx;
@@ -479,8 +479,8 @@ jv jv_array_append(jv j, jv val) {
 }
 
 jv jv_array_concat(jv a, jv b) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
-  assert(jv_get_kind(b) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
+  assert(JVP_HAS_KIND(b, JV_KIND_ARRAY));
 
   // FIXME: could be faster
   jv_array_foreach(b, i, elem) {
@@ -491,7 +491,7 @@ jv jv_array_concat(jv a, jv b) {
 }
 
 jv jv_array_slice(jv a, int start, int end) {
-  assert(jv_get_kind(a) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(a, JV_KIND_ARRAY));
   // copy/free of a coalesced
   return jvp_array_slice(a, start, end);
 }
@@ -557,7 +557,7 @@ typedef struct {
 } jvp_string;
 
 static jvp_string* jvp_string_ptr(jv a) {
-  assert(jv_get_kind(a) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(a, JV_KIND_STRING));
   return (jvp_string*)a.u.ptr;
 }
 
@@ -719,8 +719,8 @@ static uint32_t jvp_string_hash(jv jstr) {
 }
 
 static int jvp_string_equal(jv a, jv b) {
-  assert(jv_get_kind(a) == JV_KIND_STRING);
-  assert(jv_get_kind(b) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(a, JV_KIND_STRING));
+  assert(JVP_HAS_KIND(b, JV_KIND_STRING));
   jvp_string* stra = jvp_string_ptr(a);
   jvp_string* strb = jvp_string_ptr(b);
   if (jvp_string_length(stra) != jvp_string_length(strb)) return 0;
@@ -747,14 +747,14 @@ jv jv_string(const char* str) {
 }
 
 int jv_string_length_bytes(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
   int r = jvp_string_length(jvp_string_ptr(j));
   jv_free(j);
   return r;
 }
 
 int jv_string_length_codepoints(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
   const char* i = jv_string_value(j);
   const char* end = i + jv_string_length_bytes(jv_copy(j));
   int c = 0, len = 0;
@@ -765,8 +765,8 @@ int jv_string_length_codepoints(jv j) {
 
 
 jv jv_string_indexes(jv j, jv k) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
-  assert(jv_get_kind(k) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
+  assert(JVP_HAS_KIND(k, JV_KIND_STRING));
   const char *jstr = jv_string_value(j);
   const char *idxstr = jv_string_value(k);
   const char *p;
@@ -785,8 +785,8 @@ jv jv_string_indexes(jv j, jv k) {
 }
 
 jv jv_string_split(jv j, jv sep) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
-  assert(jv_get_kind(sep) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
+  assert(JVP_HAS_KIND(sep, JV_KIND_STRING));
   const char *jstr = jv_string_value(j);
   const char *jend = jstr + jv_string_length_bytes(jv_copy(j));
   const char *sepstr = jv_string_value(sep);
@@ -817,7 +817,7 @@ jv jv_string_split(jv j, jv sep) {
 }
 
 jv jv_string_explode(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
   const char* i = jv_string_value(j);
   int len = jv_string_length_bytes(jv_copy(j));
   const char* end = i + len;
@@ -830,7 +830,7 @@ jv jv_string_explode(jv j) {
 }
 
 jv jv_string_implode(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_ARRAY);
+  assert(JVP_HAS_KIND(j, JV_KIND_ARRAY));
   int len = jv_array_length(jv_copy(j));
   jv s = jv_string_empty(len);
   int i;
@@ -839,7 +839,7 @@ jv jv_string_implode(jv j) {
 
   for (i = 0; i < len; i++) {
     jv n = jv_array_get(jv_copy(j), i);
-    assert(jv_get_kind(n) == JV_KIND_NUMBER);
+    assert(JVP_HAS_KIND(n, JV_KIND_NUMBER));
     int nv = jv_number_value(n);
     if (nv > 0x10FFFF)
       nv = 0xFFFD; // U+FFFD REPLACEMENT CHARACTER
@@ -851,19 +851,19 @@ jv jv_string_implode(jv j) {
 }
 
 unsigned long jv_string_hash(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
   uint32_t hash = jvp_string_hash(j);
   jv_free(j);
   return hash;
 }
 
 const char* jv_string_value(jv j) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
   return jvp_string_ptr(j)->data;
 }
 
 jv jv_string_slice(jv j, int start, int end) {
-  assert(jv_get_kind(j) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(j, JV_KIND_STRING));
   const char *s = jv_string_value(j);
   int len = jv_string_length_bytes(jv_copy(j));
   int i;
@@ -1017,17 +1017,17 @@ static jv jvp_object_new(int size) {
 }
 
 static jvp_object* jvp_object_ptr(jv o) {
-  assert(jv_get_kind(o) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(o, JV_KIND_OBJECT));
   return (jvp_object*)o.u.ptr;
 }
 
 static uint32_t jvp_object_mask(jv o) {
-  assert(jv_get_kind(o) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(o, JV_KIND_OBJECT));
   return (o.size * 2) - 1;
 }
 
 static int jvp_object_size(jv o) {
-  assert(jv_get_kind(o) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(o, JV_KIND_OBJECT));
   return o.size;
 }
 
@@ -1075,7 +1075,7 @@ static struct object_slot* jvp_object_add_slot(jv object, jv key, int* bucket) {
 }
 
 static jv* jvp_object_read(jv object, jv key) {
-  assert(jv_get_kind(key) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   int* bucket = jvp_object_find_bucket(object, key);
   struct object_slot* slot = jvp_object_find_slot(object, key, bucket);
   if (slot == 0) return 0;
@@ -1083,7 +1083,7 @@ static jv* jvp_object_read(jv object, jv key) {
 }
 
 static void jvp_object_free(jv o) {
-  assert(jv_get_kind(o) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(o, JV_KIND_OBJECT));
   if (jvp_refcnt_dec(o.u.ptr)) {
     for (int i=0; i<jvp_object_size(o); i++) {
       struct object_slot* slot = jvp_object_get_slot(o, i);
@@ -1097,7 +1097,7 @@ static void jvp_object_free(jv o) {
 }
 
 static jv jvp_object_rehash(jv object) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
   assert(jvp_refcnt_unshared(object.u.ptr));
   int size = jvp_object_size(object);
   jv new_object = jvp_object_new(size * 2);
@@ -1116,7 +1116,7 @@ static jv jvp_object_rehash(jv object) {
 }
 
 static jv jvp_object_unshare(jv object) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
   if (jvp_refcnt_unshared(object.u.ptr))
     return object;
 
@@ -1165,7 +1165,7 @@ static jv* jvp_object_write(jv* object, jv key) {
 }
 
 static int jvp_object_delete(jv* object, jv key) {
-  assert(jv_get_kind(key) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   *object = jvp_object_unshare(*object);
   int* bucket = jvp_object_find_bucket(*object, key);
   int* prev_ptr = bucket;
@@ -1218,8 +1218,8 @@ jv jv_object() {
 }
 
 jv jv_object_get(jv object, jv key) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
-  assert(jv_get_kind(key) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+  assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   jv* slot = jvp_object_read(object, key);
   jv val;
   if (slot) {
@@ -1233,8 +1233,8 @@ jv jv_object_get(jv object, jv key) {
 }
 
 int jv_object_has(jv object, jv key) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
-  assert(jv_get_kind(key) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+  assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   jv* slot = jvp_object_read(object, key);
   int res = slot ? 1 : 0;
   jv_free(object);
@@ -1243,8 +1243,8 @@ int jv_object_has(jv object, jv key) {
 }
 
 jv jv_object_set(jv object, jv key, jv value) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
-  assert(jv_get_kind(key) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+  assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   // copy/free of object, key, value coalesced
   jv* slot = jvp_object_write(&object, key);
   jv_free(*slot);
@@ -1253,22 +1253,22 @@ jv jv_object_set(jv object, jv key, jv value) {
 }
 
 jv jv_object_delete(jv object, jv key) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
-  assert(jv_get_kind(key) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+  assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   jvp_object_delete(&object, key);
   jv_free(key);
   return object;
 }
 
 int jv_object_length(jv object) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
   int n = jvp_object_length(object);
   jv_free(object);
   return n;
 }
 
 jv jv_object_merge(jv a, jv b) {
-  assert(jv_get_kind(a) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(a, JV_KIND_OBJECT));
   jv_object_foreach(b, k, v) {
     a = jv_object_set(a, k, v);
   }
@@ -1277,14 +1277,14 @@ jv jv_object_merge(jv a, jv b) {
 }
 
 jv jv_object_merge_recursive(jv a, jv b) {
-  assert(jv_get_kind(a) == JV_KIND_OBJECT);
-  assert(jv_get_kind(b) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(a, JV_KIND_OBJECT));
+  assert(JVP_HAS_KIND(b, JV_KIND_OBJECT));
 
   jv_object_foreach(b, k, v) {
     jv elem = jv_object_get(jv_copy(a), jv_copy(k));
     if (jv_is_valid(elem) &&
-        jv_get_kind(elem) == JV_KIND_OBJECT &&
-        jv_get_kind(v) == JV_KIND_OBJECT) {
+        JVP_HAS_KIND(elem, JV_KIND_OBJECT) &&
+        JVP_HAS_KIND(v, JV_KIND_OBJECT)) {
       a = jv_object_set(a, k, jv_object_merge_recursive(elem, v));
     } else {
       jv_free(elem);
@@ -1296,8 +1296,8 @@ jv jv_object_merge_recursive(jv a, jv b) {
 }
 
 int jv_object_contains(jv a, jv b) {
-  assert(jv_get_kind(a) == JV_KIND_OBJECT);
-  assert(jv_get_kind(b) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(a, JV_KIND_OBJECT));
+  assert(JVP_HAS_KIND(b, JV_KIND_OBJECT));
   int r = 1;
 
   jv_object_foreach(b, key, b_val) {
@@ -1325,12 +1325,12 @@ int jv_object_iter_valid(jv object, int i) {
 }
 
 int jv_object_iter(jv object) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
   return jv_object_iter_next(object, -1);
 }
 
 int jv_object_iter_next(jv object, int iter) {
-  assert(jv_get_kind(object) == JV_KIND_OBJECT);
+  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
   assert(iter != ITER_FINISHED);
   struct object_slot* slot;
   do {
@@ -1346,7 +1346,7 @@ int jv_object_iter_next(jv object, int iter) {
 
 jv jv_object_iter_key(jv object, int iter) {
   jv s = jvp_object_get_slot(object, iter)->string;
-  assert(jv_get_kind(s) == JV_KIND_STRING);
+  assert(JVP_HAS_KIND(s, JV_KIND_STRING));
   return jv_copy(s);
 }
 
@@ -1400,7 +1400,7 @@ int jv_equal(jv a, jv b) {
   int r;
   if (jv_get_kind(a) != jv_get_kind(b)) {
     r = 0;
-  } else if (jv_get_kind(a) == JV_KIND_NUMBER) {
+  } else if (JVP_HAS_KIND(a, JV_KIND_NUMBER)) {
     r = jv_number_value(a) == jv_number_value(b);
   } else if (a.kind_flags == b.kind_flags &&
              a.size == b.size &&
@@ -1463,11 +1463,11 @@ int jv_contains(jv a, jv b) {
   int r = 1;
   if (jv_get_kind(a) != jv_get_kind(b)) {
     r = 0;
-  } else if (jv_get_kind(a) == JV_KIND_OBJECT) {
+  } else if (JVP_HAS_KIND(a, JV_KIND_OBJECT)) {
     r = jv_object_contains(jv_copy(a), jv_copy(b));
-  } else if (jv_get_kind(a) == JV_KIND_ARRAY) {
+  } else if (JVP_HAS_KIND(a, JV_KIND_ARRAY)) {
     r = jv_array_contains(jv_copy(a), jv_copy(b));
-  } else if (jv_get_kind(a) == JV_KIND_STRING) {
+  } else if (JVP_HAS_KIND(a, JV_KIND_STRING)) {
     r = strstr(jv_string_value(a), jv_string_value(b)) != 0;
   } else {
     r = jv_equal(jv_copy(a), jv_copy(b));

--- a/src/jv.c
+++ b/src/jv.c
@@ -203,8 +203,10 @@ double jv_number_value(jv j) {
   assert(jv_get_kind(j) == JV_KIND_NUMBER);
   if (jvp_number_is_literal(j)) {
     jvp_literal_number* n = jvp_literal_number_ptr(j);
-    // warning!
-    fprintf(stderr, "Returning %f for a literal '%.*s'", n->number, j.size, n->literal_data);
+    // the number may be truncated at this point
+    // consider printing a warning,
+    // however it's unclear what should be done in the library use case
+    // fprintf(stderr, "Returning %f for a literal '%.*s'\n", n->number, j.size, n->literal_data);
     return n->number;
   } else {
     return j.u.number;

--- a/src/jv.c
+++ b/src/jv.c
@@ -226,7 +226,7 @@ static void jvp_literal_number_free(jv j) {
   }
 }
 
-jv jv_literal_number(double number, const char * literal, int literal_length) {
+jv jv_number_with_literal(double number, const char * literal, int literal_length) {
   return jvp_literal_number_new(number, literal, literal_length);
 }
 
@@ -261,11 +261,11 @@ int jv_is_integer(jv j){
   return x == (int)x;
 }
 
-int jv_is_literal_number(jv j) {
+int jv_number_has_literal(jv j) {
   return JVP_HAS_FLAGS(j, JVP_FLAGS_NUMBER_L);
 }
 
-int jv_literal_number_literal(jv j, const char* *literal_data_out) {
+int jv_number_get_literal(jv j, const char* *literal_data_out) {
   assert(JVP_HAS_FLAGS(j, JVP_FLAGS_NUMBER_L));
   assert(literal_data_out != NULL);
   *literal_data_out = jvp_literal_number_ptr(j)->literal_data;

--- a/src/jv.h
+++ b/src/jv.h
@@ -61,8 +61,11 @@ jv jv_false(void);
 jv jv_bool(int);
 
 jv jv_number(double);
+jv jv_literal_number(double, const char*, int);
 double jv_number_value(jv);
 int jv_is_integer(jv);
+int jv_is_literal_number(jv);
+int jv_literal_number_literal(jv, const char**);
 
 jv jv_array(void);
 jv jv_array_sized(int);

--- a/src/jv.h
+++ b/src/jv.h
@@ -61,11 +61,11 @@ jv jv_false(void);
 jv jv_bool(int);
 
 jv jv_number(double);
-jv jv_literal_number(double, const char*, int);
+jv jv_number_with_literal(double, const char*, int);
 double jv_number_value(jv);
 int jv_is_integer(jv);
-int jv_is_literal_number(jv);
-int jv_literal_number_literal(jv, const char**);
+int jv_number_has_literal(jv);
+int jv_number_get_literal(jv, const char**);
 
 jv jv_array(void);
 jv jv_array_sized(int);

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -32,6 +32,8 @@ static int parse_slice(jv j, jv slice, int* pstart, int* pend) {
   } else {
     double dstart = jv_number_value(start_jv);
     double dend = jv_number_value(end_jv);
+    jv_free(start_jv);
+    jv_free(end_jv);
     if (dstart < 0) dstart += len;
     if (dend < 0) dend += len;
     if (dstart < 0) dstart = 0;
@@ -69,6 +71,7 @@ jv jv_get(jv t, jv k) {
         jv_free(v);
         v = jv_null();
       }
+      jv_free(k);
     } else {
       jv_free(t);
       jv_free(k);
@@ -135,6 +138,7 @@ jv jv_set(jv t, jv k, jv v) {
              (jv_get_kind(t) == JV_KIND_ARRAY || isnull)) {
     if (isnull) t = jv_array();
     t = jv_array_set(t, (int)jv_number_value(k), v);
+    jv_free(k);
   } else if (jv_get_kind(k) == JV_KIND_OBJECT &&
              (jv_get_kind(t) == JV_KIND_ARRAY || isnull)) {
     if (isnull) t = jv_array();
@@ -202,6 +206,7 @@ jv jv_has(jv t, jv k) {
              jv_get_kind(k) == JV_KIND_NUMBER) {
     jv elem = jv_array_get(t, (int)jv_number_value(k));
     ret = jv_bool(jv_is_valid(elem));
+    jv_free(k);
     jv_free(elem);
   } else {
     ret = jv_invalid_with_msg(jv_string_fmt("Cannot check whether %s has a %s key",
@@ -233,6 +238,7 @@ static jv jv_dels(jv t, jv keys) {
         } else {
           nonneg_keys = jv_array_append(nonneg_keys, key);
         }
+        jv_free(key);
       } else if (jv_get_kind(key) == JV_KIND_OBJECT) {
         int start, end;
         if (parse_slice(jv_copy(t), key, &start, &end)) {
@@ -240,6 +246,7 @@ static jv jv_dels(jv t, jv keys) {
           ends = jv_array_append(ends, jv_number(end));
         } else {
           jv_free(new_array);
+          jv_free(key);
           new_array = jv_invalid_with_msg(jv_string_fmt("Start and end indices of an array slice must be numbers"));
           goto arr_out;
         }

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -124,14 +124,19 @@ static void parser_free(struct jv_parser* p) {
 
 static pfunc value(struct jv_parser* p, jv val) {
   if ((p->flags & JV_PARSE_STREAMING)) {
-    if (jv_is_valid(p->next) || p->last_seen == JV_LAST_VALUE)
+    if (jv_is_valid(p->next) || p->last_seen == JV_LAST_VALUE) {
+      jv_free(val);
       return "Expected separator between values";
+    }
     if (p->stacklen > 0)
       p->last_seen = JV_LAST_VALUE;
     else
       p->last_seen = JV_LAST_NONE;
   } else {
-    if (jv_is_valid(p->next)) return "Expected separator between values";
+    if (jv_is_valid(p->next)) {
+      jv_free(val);
+      return "Expected separator between values";
+    }
   }
   jv_free(p->next);
   p->next = val;

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -505,7 +505,7 @@ static pfunc check_literal(struct jv_parser* p) {
     double d = jvp_strtod(&p->dtoa, p->tokenbuf, &end);
     if (end == 0 || *end != 0)
       return "Invalid numeric literal";
-    TRY(value(p, jv_literal_number(d, p->tokenbuf, (end - p->tokenbuf))));
+    TRY(value(p, jv_number_with_literal(d, p->tokenbuf, (end - p->tokenbuf))));
   }
   p->tokenpos = 0;
   return 0;

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -496,7 +496,7 @@ static pfunc check_literal(struct jv_parser* p) {
     double d = jvp_strtod(&p->dtoa, p->tokenbuf, &end);
     if (end == 0 || *end != 0)
       return "Invalid numeric literal";
-    TRY(value(p, jv_number(d)));
+    TRY(value(p, jv_literal_number(d, p->tokenbuf, (end - p->tokenbuf))));
   }
   p->tokenpos = 0;
   return 0;

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -256,8 +256,12 @@ static pfunc stream_token(struct jv_parser* p, char ch) {
     break;
 
   case ':':
-    if (p->stacklen == 0 || jv_get_kind(jv_array_get(jv_copy(p->path), p->stacklen - 1)) == JV_KIND_NUMBER)
+    last = jv_invalid();
+    if (p->stacklen == 0 || jv_get_kind(last = jv_array_get(jv_copy(p->path), p->stacklen - 1)) == JV_KIND_NUMBER) {
+      jv_free(last);
       return "':' not as part of an object";
+    }
+    jv_free(last);
     if (!jv_is_valid(p->next) || p->last_seen == JV_LAST_NONE)
       return "Expected string key before ':'";
     if (jv_get_kind(p->next) != JV_KIND_STRING)

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -229,15 +229,21 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     put_str("true", F, S, flags & JV_PRINT_ISATTY);
     break;
   case JV_KIND_NUMBER: {
-    double d = jv_number_value(x);
-    if (d != d) {
-      // JSON doesn't have NaN, so we'll render it as "null"
-      put_str("null", F, S, flags & JV_PRINT_ISATTY);
+    if (jv_is_literal_number(x)) {
+      const char * literal_data;
+      int length = jv_literal_number_literal(x, &literal_data);
+      put_buf(literal_data, length, F, S, flags & JV_PRINT_ISATTY);
     } else {
-      // Normalise infinities to something we can print in valid JSON
-      if (d > DBL_MAX) d = DBL_MAX;
-      if (d < -DBL_MAX) d = -DBL_MAX;
-      put_str(jvp_dtoa_fmt(C, buf, d), F, S, flags & JV_PRINT_ISATTY);
+      double d = jv_number_value(x);
+      if (d != d) {
+        // JSON doesn't have NaN, so we'll render it as "null"
+        put_str("null", F, S, flags & JV_PRINT_ISATTY);
+      } else {
+        // Normalise infinities to something we can print in valid JSON
+        if (d > DBL_MAX) d = DBL_MAX;
+        if (d < -DBL_MAX) d = -DBL_MAX;
+        put_str(jvp_dtoa_fmt(C, buf, d), F, S, flags & JV_PRINT_ISATTY);
+      }
     }
     break;
   }

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -229,9 +229,9 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     put_str("true", F, S, flags & JV_PRINT_ISATTY);
     break;
   case JV_KIND_NUMBER: {
-    if (jv_is_literal_number(x)) {
+    if (jv_number_has_literal(x)) {
       const char * literal_data;
-      int length = jv_literal_number_literal(x, &literal_data);
+      int length = jv_number_get_literal(x, &literal_data);
       put_buf(literal_data, length, F, S, flags & JV_PRINT_ISATTY);
     } else {
       double d = jv_number_value(x);

--- a/src/parser.c
+++ b/src/parser.c
@@ -362,20 +362,20 @@ static block constant_fold(block a, block b, int op) {
     double na = jv_number_value(jv_a);
     double nb = jv_number_value(jv_b);
 
-    // consumes the numbers
-    int equal = jv_equal(jv_a, jv_b);
+    jv_free(jv_a);
+    jv_free(jv_b);
 
     switch (op) {
     case '+': res = jv_number(na + nb); break;
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;
-    case EQ:  res = (equal ? jv_true() : jv_false()); break;
-    case NEQ: res = (!equal ? jv_true() : jv_false()); break;
+    case EQ:  res = (na == nb ? jv_true() : jv_false()); break;
+    case NEQ: res = (na != nb ? jv_true() : jv_false()); break;
     case '<': res = (na < nb ? jv_true() : jv_false()); break;
     case '>': res = (na > nb ? jv_true() : jv_false()); break;
-    case LESSEQ: res = ((equal || (na <= nb)) ? jv_true() : jv_false()); break;
-    case GREATEREQ: res = ((equal || (na >= nb)) ? jv_true() : jv_false()); break;
+    case LESSEQ: res = (na <= nb ? jv_true() : jv_false()); break;
+    case GREATEREQ: res = (na >= nb ? jv_true() : jv_false()); break;
     default: break;
     }
   } else if (op == '+' && block_const_kind(a) == JV_KIND_STRING) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -312,7 +312,7 @@ static jv check_object_key(block k) {
     char errbuf[15];
     return jv_string_fmt("Cannot use %s (%s) as object key",
         jv_kind_name(block_const_kind(k)),
-        jv_dump_string_trunc(jv_copy(block_const(k)), errbuf, sizeof(errbuf)));
+        jv_dump_string_trunc(block_const(k), errbuf, sizeof(errbuf)));
   }
   return jv_invalid();
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.1.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.1"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -356,19 +356,26 @@ static block constant_fold(block a, block b, int op) {
   jv res = jv_invalid();
 
   if (block_const_kind(a) == JV_KIND_NUMBER) {
-    double na = jv_number_value(block_const(a));
-    double nb = jv_number_value(block_const(b));
+    jv jv_a = block_const(a);
+    jv jv_b = block_const(b);
+
+    double na = jv_number_value(jv_a);
+    double nb = jv_number_value(jv_b);
+
+    // consumes the numbers
+    int equal = jv_equal(jv_a, jv_b);
+
     switch (op) {
     case '+': res = jv_number(na + nb); break;
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;
-    case EQ:  res = (na == nb ? jv_true() : jv_false()); break;
-    case NEQ: res = (na != nb ? jv_true() : jv_false()); break;
+    case EQ:  res = (equal ? jv_true() : jv_false()); break;
+    case NEQ: res = (!equal ? jv_true() : jv_false()); break;
     case '<': res = (na < nb ? jv_true() : jv_false()); break;
     case '>': res = (na > nb ? jv_true() : jv_false()); break;
-    case LESSEQ: res = (na <= nb ? jv_true() : jv_false()); break;
-    case GREATEREQ: res = (na >= nb ? jv_true() : jv_false()); break;
+    case LESSEQ: res = ((equal || (na <= nb)) ? jv_true() : jv_false()); break;
+    case GREATEREQ: res = ((equal || (na >= nb)) ? jv_true() : jv_false()); break;
     default: break;
     }
   } else if (op == '+' && block_const_kind(a) == JV_KIND_STRING) {
@@ -434,7 +441,7 @@ static block gen_update(block object, block val, int optype) {
 }
 
 
-#line 438 "src/parser.c" /* yacc.c:358  */
+#line 445 "src/parser.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -455,13 +462,13 @@ typedef signed char yytype_int8;
 #ifdef YYTYPE_UINT16
 typedef YYTYPE_UINT16 yytype_uint16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef unsigned short yytype_uint16;
 #endif
 
 #ifdef YYTYPE_INT16
 typedef YYTYPE_INT16 yytype_int16;
 #else
-typedef short int yytype_int16;
+typedef short yytype_int16;
 #endif
 
 #ifndef YYSIZE_T
@@ -473,7 +480,7 @@ typedef short int yytype_int16;
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
@@ -525,7 +532,7 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
 # define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
     _Pragma ("GCC diagnostic push") \
@@ -695,7 +702,7 @@ union yyalloc
 #define YYMAXUTOK   302
 
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  ((unsigned) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, without out-of-bounds checking.  */
@@ -738,23 +745,23 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   300,   300,   303,   308,   311,   322,   325,   330,   333,
-     338,   342,   345,   349,   353,   357,   360,   365,   369,   373,
-     378,   385,   389,   393,   397,   401,   405,   409,   413,   417,
-     421,   425,   429,   433,   437,   441,   445,   449,   455,   461,
-     465,   469,   473,   477,   481,   485,   489,   493,   498,   501,
-     518,   527,   534,   542,   553,   558,   564,   567,   572,   577,
-     584,   584,   588,   588,   595,   598,   601,   607,   610,   615,
-     618,   621,   627,   630,   633,   641,   645,   648,   651,   654,
-     657,   660,   663,   666,   669,   673,   679,   682,   685,   688,
-     691,   694,   697,   700,   703,   706,   709,   712,   715,   718,
-     721,   724,   727,   734,   738,   742,   754,   759,   760,   761,
-     762,   765,   768,   773,   778,   781,   786,   789,   794,   798,
-     801,   806,   809,   814,   817,   822,   825,   828,   831,   834,
-     837,   845,   851,   854,   857,   860,   863,   866,   869,   872,
-     875,   878,   881,   884,   887,   890,   893,   896,   899,   902,
-     905,   910,   913,   914,   915,   918,   921,   924,   927,   931,
-     935,   939,   947
+       0,   307,   307,   310,   315,   318,   329,   332,   337,   340,
+     345,   349,   352,   356,   360,   364,   367,   372,   376,   380,
+     385,   392,   396,   400,   404,   408,   412,   416,   420,   424,
+     428,   432,   436,   440,   444,   448,   452,   456,   462,   468,
+     472,   476,   480,   484,   488,   492,   496,   500,   505,   508,
+     525,   534,   541,   549,   560,   565,   571,   574,   579,   584,
+     591,   591,   595,   595,   602,   605,   608,   614,   617,   622,
+     625,   628,   634,   637,   640,   648,   652,   655,   658,   661,
+     664,   667,   670,   673,   676,   680,   686,   689,   692,   695,
+     698,   701,   704,   707,   710,   713,   716,   719,   722,   725,
+     728,   731,   734,   741,   745,   749,   761,   766,   767,   768,
+     769,   772,   775,   780,   785,   788,   793,   796,   801,   805,
+     808,   813,   816,   821,   824,   829,   832,   835,   838,   841,
+     844,   852,   858,   861,   864,   867,   870,   873,   876,   879,
+     882,   885,   888,   891,   894,   897,   900,   903,   906,   909,
+     912,   917,   920,   921,   922,   925,   928,   931,   934,   938,
+     942,   946,   954
 };
 #endif
 
@@ -1593,7 +1600,7 @@ do {                                                            \
 static void
 yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, block* answer, int* errors, struct locfile* locations, struct lexer_param* lexer_param_ptr)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  unsigned long yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
@@ -1819,6 +1826,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -1887,189 +1895,189 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 4: /* IDENT  */
-#line 36 "src/parser.y" /* yacc.c:1257  */
+#line 36 "src/parser.y" /* yacc.c:1258  */
       { jv_free(((*yyvaluep).literal)); }
-#line 1893 "src/parser.c" /* yacc.c:1257  */
+#line 1901 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 5: /* FIELD  */
-#line 36 "src/parser.y" /* yacc.c:1257  */
+#line 36 "src/parser.y" /* yacc.c:1258  */
       { jv_free(((*yyvaluep).literal)); }
-#line 1899 "src/parser.c" /* yacc.c:1257  */
+#line 1907 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 6: /* LITERAL  */
-#line 36 "src/parser.y" /* yacc.c:1257  */
+#line 36 "src/parser.y" /* yacc.c:1258  */
       { jv_free(((*yyvaluep).literal)); }
-#line 1905 "src/parser.c" /* yacc.c:1257  */
+#line 1913 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 7: /* FORMAT  */
-#line 36 "src/parser.y" /* yacc.c:1257  */
+#line 36 "src/parser.y" /* yacc.c:1258  */
       { jv_free(((*yyvaluep).literal)); }
-#line 1911 "src/parser.c" /* yacc.c:1257  */
+#line 1919 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 42: /* QQSTRING_TEXT  */
-#line 36 "src/parser.y" /* yacc.c:1257  */
+#line 36 "src/parser.y" /* yacc.c:1258  */
       { jv_free(((*yyvaluep).literal)); }
-#line 1917 "src/parser.c" /* yacc.c:1257  */
+#line 1925 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 71: /* Module  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1923 "src/parser.c" /* yacc.c:1257  */
+#line 1931 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 72: /* Imports  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1929 "src/parser.c" /* yacc.c:1257  */
+#line 1937 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 73: /* FuncDefs  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1935 "src/parser.c" /* yacc.c:1257  */
+#line 1943 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 74: /* Exp  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1941 "src/parser.c" /* yacc.c:1257  */
+#line 1949 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 75: /* Import  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1947 "src/parser.c" /* yacc.c:1257  */
+#line 1955 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 76: /* ImportWhat  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1953 "src/parser.c" /* yacc.c:1257  */
+#line 1961 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 77: /* ImportFrom  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1959 "src/parser.c" /* yacc.c:1257  */
+#line 1967 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 78: /* FuncDef  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1965 "src/parser.c" /* yacc.c:1257  */
+#line 1973 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 79: /* Params  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1971 "src/parser.c" /* yacc.c:1257  */
+#line 1979 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 80: /* Param  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1977 "src/parser.c" /* yacc.c:1257  */
+#line 1985 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 81: /* String  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1983 "src/parser.c" /* yacc.c:1257  */
+#line 1991 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 84: /* QQString  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1989 "src/parser.c" /* yacc.c:1257  */
+#line 1997 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 85: /* ElseBody  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 1995 "src/parser.c" /* yacc.c:1257  */
+#line 2003 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 86: /* ExpD  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2001 "src/parser.c" /* yacc.c:1257  */
+#line 2009 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 87: /* Term  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2007 "src/parser.c" /* yacc.c:1257  */
+#line 2015 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 88: /* Args  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2013 "src/parser.c" /* yacc.c:1257  */
+#line 2021 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 89: /* Arg  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2019 "src/parser.c" /* yacc.c:1257  */
+#line 2027 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 90: /* RepPatterns  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2025 "src/parser.c" /* yacc.c:1257  */
+#line 2033 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 91: /* Patterns  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2031 "src/parser.c" /* yacc.c:1257  */
+#line 2039 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 92: /* Pattern  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2037 "src/parser.c" /* yacc.c:1257  */
+#line 2045 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 93: /* ArrayPats  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2043 "src/parser.c" /* yacc.c:1257  */
+#line 2051 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 94: /* ObjPats  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2049 "src/parser.c" /* yacc.c:1257  */
+#line 2057 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 95: /* ObjPat  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2055 "src/parser.c" /* yacc.c:1257  */
+#line 2063 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 96: /* Keyword  */
-#line 36 "src/parser.y" /* yacc.c:1257  */
+#line 36 "src/parser.y" /* yacc.c:1258  */
       { jv_free(((*yyvaluep).literal)); }
-#line 2061 "src/parser.c" /* yacc.c:1257  */
+#line 2069 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 97: /* MkDict  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2067 "src/parser.c" /* yacc.c:1257  */
+#line 2075 "src/parser.c" /* yacc.c:1258  */
         break;
 
     case 98: /* MkDictPair  */
-#line 37 "src/parser.y" /* yacc.c:1257  */
+#line 37 "src/parser.y" /* yacc.c:1258  */
       { block_free(((*yyvaluep).blk)); }
-#line 2073 "src/parser.c" /* yacc.c:1257  */
+#line 2081 "src/parser.c" /* yacc.c:1258  */
         break;
 
 
@@ -2249,7 +2257,7 @@ YYLTYPE yylloc = yyloc_default;
       yylsp = yyls + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+                  (unsigned long) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
@@ -2355,37 +2363,38 @@ yyreduce:
      GCC warning that YYVAL may be used uninitialized.  */
   yyval = yyvsp[1-yylen];
 
-  /* Default location.  */
+  /* Default location. */
   YYLLOC_DEFAULT (yyloc, (yylsp - yylen), yylen);
+  yyerror_range[1] = yyloc;
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
         case 2:
-#line 300 "src/parser.y" /* yacc.c:1646  */
+#line 307 "src/parser.y" /* yacc.c:1666  */
     {
   *answer = BLOCK((yyvsp[-2].blk), (yyvsp[-1].blk), gen_op_simple(TOP), (yyvsp[0].blk));
 }
-#line 2369 "src/parser.c" /* yacc.c:1646  */
+#line 2378 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 3:
-#line 303 "src/parser.y" /* yacc.c:1646  */
+#line 310 "src/parser.y" /* yacc.c:1666  */
     {
   *answer = BLOCK((yyvsp[-2].blk), (yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2377 "src/parser.c" /* yacc.c:1646  */
+#line 2386 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 4:
-#line 308 "src/parser.y" /* yacc.c:1646  */
+#line 315 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_noop();
 }
-#line 2385 "src/parser.c" /* yacc.c:1646  */
+#line 2394 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 5:
-#line 311 "src/parser.y" /* yacc.c:1646  */
+#line 318 "src/parser.y" /* yacc.c:1666  */
     {
   if (!block_is_const((yyvsp[-1].blk))) {
     FAIL((yyloc), "Module metadata must be constant");
@@ -2395,366 +2404,366 @@ yyreduce:
     (yyval.blk) = gen_module((yyvsp[-1].blk));
   }
 }
-#line 2399 "src/parser.c" /* yacc.c:1646  */
+#line 2408 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 6:
-#line 322 "src/parser.y" /* yacc.c:1646  */
+#line 329 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_noop();
 }
-#line 2407 "src/parser.c" /* yacc.c:1646  */
+#line 2416 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 7:
-#line 325 "src/parser.y" /* yacc.c:1646  */
+#line 332 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2415 "src/parser.c" /* yacc.c:1646  */
+#line 2424 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 8:
-#line 330 "src/parser.y" /* yacc.c:1646  */
+#line 337 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_noop();
 }
-#line 2423 "src/parser.c" /* yacc.c:1646  */
+#line 2432 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 9:
-#line 333 "src/parser.y" /* yacc.c:1646  */
+#line 340 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = block_bind((yyvsp[-1].blk), (yyvsp[0].blk), OP_IS_CALL_PSEUDO);
 }
-#line 2431 "src/parser.c" /* yacc.c:1646  */
+#line 2440 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 10:
-#line 338 "src/parser.y" /* yacc.c:1646  */
+#line 345 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = block_bind_referenced((yyvsp[-1].blk), (yyvsp[0].blk), OP_IS_CALL_PSEUDO);
 }
-#line 2439 "src/parser.c" /* yacc.c:1646  */
+#line 2448 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 11:
-#line 342 "src/parser.y" /* yacc.c:1646  */
+#line 349 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_destructure((yyvsp[-4].blk), (yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2447 "src/parser.c" /* yacc.c:1646  */
+#line 2456 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 12:
-#line 345 "src/parser.y" /* yacc.c:1646  */
+#line 352 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_reduce((yyvsp[-7].blk), (yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 2455 "src/parser.c" /* yacc.c:1646  */
+#line 2464 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 13:
-#line 349 "src/parser.y" /* yacc.c:1646  */
+#line 356 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_foreach((yyvsp[-9].blk), (yyvsp[-7].blk), (yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 2463 "src/parser.c" /* yacc.c:1646  */
+#line 2472 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 14:
-#line 353 "src/parser.y" /* yacc.c:1646  */
+#line 360 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_foreach((yyvsp[-7].blk), (yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk), gen_noop());
 }
-#line 2471 "src/parser.c" /* yacc.c:1646  */
+#line 2480 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 15:
-#line 357 "src/parser.y" /* yacc.c:1646  */
+#line 364 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_cond((yyvsp[-3].blk), (yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2479 "src/parser.c" /* yacc.c:1646  */
+#line 2488 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 16:
-#line 360 "src/parser.y" /* yacc.c:1646  */
+#line 367 "src/parser.y" /* yacc.c:1666  */
     {
   FAIL((yyloc), "Possibly unterminated 'if' statement");
   (yyval.blk) = (yyvsp[-2].blk);
 }
-#line 2488 "src/parser.c" /* yacc.c:1646  */
+#line 2497 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 17:
-#line 365 "src/parser.y" /* yacc.c:1646  */
+#line 372 "src/parser.y" /* yacc.c:1666  */
     {
   //$$ = BLOCK(gen_op_target(FORK_OPT, $2), $2, $4);
   (yyval.blk) = gen_try((yyvsp[-2].blk), gen_try_handler((yyvsp[0].blk)));
 }
-#line 2497 "src/parser.c" /* yacc.c:1646  */
+#line 2506 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 18:
-#line 369 "src/parser.y" /* yacc.c:1646  */
+#line 376 "src/parser.y" /* yacc.c:1666  */
     {
   //$$ = BLOCK(gen_op_target(FORK_OPT, $2), $2, gen_op_simple(BACKTRACK));
   (yyval.blk) = gen_try((yyvsp[0].blk), gen_op_simple(BACKTRACK));
 }
-#line 2506 "src/parser.c" /* yacc.c:1646  */
+#line 2515 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 19:
-#line 373 "src/parser.y" /* yacc.c:1646  */
+#line 380 "src/parser.y" /* yacc.c:1666  */
     {
   FAIL((yyloc), "Possibly unterminated 'try' statement");
   (yyval.blk) = (yyvsp[-2].blk);
 }
-#line 2515 "src/parser.c" /* yacc.c:1646  */
+#line 2524 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 20:
-#line 378 "src/parser.y" /* yacc.c:1646  */
+#line 385 "src/parser.y" /* yacc.c:1666  */
     {
   jv v = jv_string_fmt("*label-%s", jv_string_value((yyvsp[-2].literal)));
   (yyval.blk) = gen_location((yyloc), locations, gen_label(jv_string_value(v), (yyvsp[0].blk)));
   jv_free((yyvsp[-2].literal));
   jv_free(v);
 }
-#line 2526 "src/parser.c" /* yacc.c:1646  */
+#line 2535 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 21:
-#line 385 "src/parser.y" /* yacc.c:1646  */
+#line 392 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_try((yyvsp[-1].blk), gen_op_simple(BACKTRACK));
 }
-#line 2534 "src/parser.c" /* yacc.c:1646  */
+#line 2543 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 22:
-#line 389 "src/parser.y" /* yacc.c:1646  */
+#line 396 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_call("_assign", BLOCK(gen_lambda((yyvsp[-2].blk)), gen_lambda((yyvsp[0].blk))));
 }
-#line 2542 "src/parser.c" /* yacc.c:1646  */
+#line 2551 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 23:
-#line 393 "src/parser.y" /* yacc.c:1646  */
+#line 400 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_or((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2550 "src/parser.c" /* yacc.c:1646  */
+#line 2559 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 24:
-#line 397 "src/parser.y" /* yacc.c:1646  */
+#line 404 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_and((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2558 "src/parser.c" /* yacc.c:1646  */
+#line 2567 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 25:
-#line 401 "src/parser.y" /* yacc.c:1646  */
+#line 408 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_definedor((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2566 "src/parser.c" /* yacc.c:1646  */
+#line 2575 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 26:
-#line 405 "src/parser.y" /* yacc.c:1646  */
+#line 412 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_definedor_assign((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2574 "src/parser.c" /* yacc.c:1646  */
+#line 2583 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 27:
-#line 409 "src/parser.y" /* yacc.c:1646  */
+#line 416 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_call("_modify", BLOCK(gen_lambda((yyvsp[-2].blk)), gen_lambda((yyvsp[0].blk))));
 }
-#line 2582 "src/parser.c" /* yacc.c:1646  */
+#line 2591 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 28:
-#line 413 "src/parser.y" /* yacc.c:1646  */
+#line 420 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2590 "src/parser.c" /* yacc.c:1646  */
+#line 2599 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 29:
-#line 417 "src/parser.y" /* yacc.c:1646  */
+#line 424 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_both((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2598 "src/parser.c" /* yacc.c:1646  */
+#line 2607 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 30:
-#line 421 "src/parser.y" /* yacc.c:1646  */
+#line 428 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '+');
 }
-#line 2606 "src/parser.c" /* yacc.c:1646  */
+#line 2615 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 31:
-#line 425 "src/parser.y" /* yacc.c:1646  */
+#line 432 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '+');
 }
-#line 2614 "src/parser.c" /* yacc.c:1646  */
+#line 2623 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 32:
-#line 429 "src/parser.y" /* yacc.c:1646  */
+#line 436 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[0].blk), gen_call("_negate", gen_noop()));
 }
-#line 2622 "src/parser.c" /* yacc.c:1646  */
+#line 2631 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 33:
-#line 433 "src/parser.y" /* yacc.c:1646  */
+#line 440 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '-');
 }
-#line 2630 "src/parser.c" /* yacc.c:1646  */
+#line 2639 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 34:
-#line 437 "src/parser.y" /* yacc.c:1646  */
+#line 444 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '-');
 }
-#line 2638 "src/parser.c" /* yacc.c:1646  */
+#line 2647 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 35:
-#line 441 "src/parser.y" /* yacc.c:1646  */
+#line 448 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '*');
 }
-#line 2646 "src/parser.c" /* yacc.c:1646  */
+#line 2655 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 36:
-#line 445 "src/parser.y" /* yacc.c:1646  */
+#line 452 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '*');
 }
-#line 2654 "src/parser.c" /* yacc.c:1646  */
+#line 2663 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 37:
-#line 449 "src/parser.y" /* yacc.c:1646  */
+#line 456 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '/');
   if (block_is_const_inf((yyval.blk)))
     FAIL((yyloc), "Division by zero?");
 }
-#line 2664 "src/parser.c" /* yacc.c:1646  */
+#line 2673 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 38:
-#line 455 "src/parser.y" /* yacc.c:1646  */
+#line 462 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '%');
   if (block_is_const_inf((yyval.blk)))
     FAIL((yyloc), "Remainder by zero?");
 }
-#line 2674 "src/parser.c" /* yacc.c:1646  */
+#line 2683 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 39:
-#line 461 "src/parser.y" /* yacc.c:1646  */
+#line 468 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '/');
 }
-#line 2682 "src/parser.c" /* yacc.c:1646  */
+#line 2691 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 40:
-#line 465 "src/parser.y" /* yacc.c:1646  */
+#line 472 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '%');
 }
-#line 2690 "src/parser.c" /* yacc.c:1646  */
+#line 2699 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 41:
-#line 469 "src/parser.y" /* yacc.c:1646  */
+#line 476 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), EQ);
 }
-#line 2698 "src/parser.c" /* yacc.c:1646  */
+#line 2707 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 42:
-#line 473 "src/parser.y" /* yacc.c:1646  */
+#line 480 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), NEQ);
 }
-#line 2706 "src/parser.c" /* yacc.c:1646  */
+#line 2715 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 43:
-#line 477 "src/parser.y" /* yacc.c:1646  */
+#line 484 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '<');
 }
-#line 2714 "src/parser.c" /* yacc.c:1646  */
+#line 2723 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 44:
-#line 481 "src/parser.y" /* yacc.c:1646  */
+#line 488 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '>');
 }
-#line 2722 "src/parser.c" /* yacc.c:1646  */
+#line 2731 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 45:
-#line 485 "src/parser.y" /* yacc.c:1646  */
+#line 492 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), LESSEQ);
 }
-#line 2730 "src/parser.c" /* yacc.c:1646  */
+#line 2739 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 46:
-#line 489 "src/parser.y" /* yacc.c:1646  */
+#line 496 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), GREATEREQ);
 }
-#line 2738 "src/parser.c" /* yacc.c:1646  */
+#line 2747 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 47:
-#line 493 "src/parser.y" /* yacc.c:1646  */
+#line 500 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 2746 "src/parser.c" /* yacc.c:1646  */
+#line 2755 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 48:
-#line 498 "src/parser.y" /* yacc.c:1646  */
+#line 505 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[-1].blk);
 }
-#line 2754 "src/parser.c" /* yacc.c:1646  */
+#line 2763 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 49:
-#line 501 "src/parser.y" /* yacc.c:1646  */
+#line 508 "src/parser.y" /* yacc.c:1666  */
     {
   if (!block_is_const((yyvsp[-1].blk))) {
     FAIL((yyloc), "Module metadata must be constant");
@@ -2770,11 +2779,11 @@ yyreduce:
     (yyval.blk) = gen_import_meta((yyvsp[-2].blk), (yyvsp[-1].blk));
   }
 }
-#line 2774 "src/parser.c" /* yacc.c:1646  */
+#line 2783 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 50:
-#line 518 "src/parser.y" /* yacc.c:1646  */
+#line 525 "src/parser.y" /* yacc.c:1666  */
     {
   jv v = block_const((yyvsp[-3].blk));
   // XXX Make gen_import take only blocks and the int is_data so we
@@ -2784,11 +2793,11 @@ yyreduce:
   jv_free((yyvsp[0].literal));
   jv_free(v);
 }
-#line 2788 "src/parser.c" /* yacc.c:1646  */
+#line 2797 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 51:
-#line 527 "src/parser.y" /* yacc.c:1646  */
+#line 534 "src/parser.y" /* yacc.c:1666  */
     {
   jv v = block_const((yyvsp[-2].blk));
   (yyval.blk) = gen_import(jv_string_value(v), jv_string_value((yyvsp[0].literal)), 0);
@@ -2796,22 +2805,22 @@ yyreduce:
   jv_free((yyvsp[0].literal));
   jv_free(v);
 }
-#line 2800 "src/parser.c" /* yacc.c:1646  */
+#line 2809 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 52:
-#line 534 "src/parser.y" /* yacc.c:1646  */
+#line 541 "src/parser.y" /* yacc.c:1666  */
     {
   jv v = block_const((yyvsp[0].blk));
   (yyval.blk) = gen_import(jv_string_value(v), NULL, 0);
   block_free((yyvsp[0].blk));
   jv_free(v);
 }
-#line 2811 "src/parser.c" /* yacc.c:1646  */
+#line 2820 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 53:
-#line 542 "src/parser.y" /* yacc.c:1646  */
+#line 549 "src/parser.y" /* yacc.c:1666  */
     {
   if (!block_is_const((yyvsp[0].blk))) {
     FAIL((yyloc), "Import path must be constant");
@@ -2821,173 +2830,173 @@ yyreduce:
     (yyval.blk) = (yyvsp[0].blk);
   }
 }
-#line 2825 "src/parser.c" /* yacc.c:1646  */
+#line 2834 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 54:
-#line 553 "src/parser.y" /* yacc.c:1646  */
+#line 560 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_function(jv_string_value((yyvsp[-3].literal)), gen_noop(), (yyvsp[-1].blk));
   jv_free((yyvsp[-3].literal));
 }
-#line 2834 "src/parser.c" /* yacc.c:1646  */
+#line 2843 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 55:
-#line 558 "src/parser.y" /* yacc.c:1646  */
+#line 565 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_function(jv_string_value((yyvsp[-6].literal)), (yyvsp[-4].blk), (yyvsp[-1].blk));
   jv_free((yyvsp[-6].literal));
 }
-#line 2843 "src/parser.c" /* yacc.c:1646  */
+#line 2852 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 56:
-#line 564 "src/parser.y" /* yacc.c:1646  */
+#line 571 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 2851 "src/parser.c" /* yacc.c:1646  */
+#line 2860 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 57:
-#line 567 "src/parser.y" /* yacc.c:1646  */
+#line 574 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2859 "src/parser.c" /* yacc.c:1646  */
+#line 2868 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 58:
-#line 572 "src/parser.y" /* yacc.c:1646  */
+#line 579 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_param_regular(jv_string_value((yyvsp[0].literal)));
   jv_free((yyvsp[0].literal));
 }
-#line 2868 "src/parser.c" /* yacc.c:1646  */
+#line 2877 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 59:
-#line 577 "src/parser.y" /* yacc.c:1646  */
+#line 584 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_param(jv_string_value((yyvsp[0].literal)));
   jv_free((yyvsp[0].literal));
 }
-#line 2877 "src/parser.c" /* yacc.c:1646  */
+#line 2886 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 60:
-#line 584 "src/parser.y" /* yacc.c:1646  */
+#line 591 "src/parser.y" /* yacc.c:1666  */
     { (yyval.literal) = jv_string("text"); }
-#line 2883 "src/parser.c" /* yacc.c:1646  */
+#line 2892 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 61:
-#line 584 "src/parser.y" /* yacc.c:1646  */
+#line 591 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[-1].blk);
   jv_free((yyvsp[-2].literal));
 }
-#line 2892 "src/parser.c" /* yacc.c:1646  */
+#line 2901 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 62:
-#line 588 "src/parser.y" /* yacc.c:1646  */
+#line 595 "src/parser.y" /* yacc.c:1666  */
     { (yyval.literal) = (yyvsp[-1].literal); }
-#line 2898 "src/parser.c" /* yacc.c:1646  */
+#line 2907 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 63:
-#line 588 "src/parser.y" /* yacc.c:1646  */
+#line 595 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[-1].blk);
   jv_free((yyvsp[-2].literal));
 }
-#line 2907 "src/parser.c" /* yacc.c:1646  */
+#line 2916 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 64:
-#line 595 "src/parser.y" /* yacc.c:1646  */
+#line 602 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_const(jv_string(""));
 }
-#line 2915 "src/parser.c" /* yacc.c:1646  */
+#line 2924 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 65:
-#line 598 "src/parser.y" /* yacc.c:1646  */
+#line 605 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-1].blk), gen_const((yyvsp[0].literal)), '+');
 }
-#line 2923 "src/parser.c" /* yacc.c:1646  */
+#line 2932 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 66:
-#line 601 "src/parser.y" /* yacc.c:1646  */
+#line 608 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_binop((yyvsp[-3].blk), gen_format((yyvsp[-1].blk), jv_copy((yyvsp[-4].literal))), '+');
 }
-#line 2931 "src/parser.c" /* yacc.c:1646  */
+#line 2940 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 67:
-#line 607 "src/parser.y" /* yacc.c:1646  */
+#line 614 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_cond((yyvsp[-3].blk), (yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2939 "src/parser.c" /* yacc.c:1646  */
+#line 2948 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 68:
-#line 610 "src/parser.y" /* yacc.c:1646  */
+#line 617 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[-1].blk);
 }
-#line 2947 "src/parser.c" /* yacc.c:1646  */
+#line 2956 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 69:
-#line 615 "src/parser.y" /* yacc.c:1646  */
+#line 622 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2955 "src/parser.c" /* yacc.c:1646  */
+#line 2964 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 70:
-#line 618 "src/parser.y" /* yacc.c:1646  */
+#line 625 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[0].blk), gen_call("_negate", gen_noop()));
 }
-#line 2963 "src/parser.c" /* yacc.c:1646  */
+#line 2972 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 71:
-#line 621 "src/parser.y" /* yacc.c:1646  */
+#line 628 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 2971 "src/parser.c" /* yacc.c:1646  */
+#line 2980 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 72:
-#line 627 "src/parser.y" /* yacc.c:1646  */
+#line 634 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_noop();
 }
-#line 2979 "src/parser.c" /* yacc.c:1646  */
+#line 2988 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 73:
-#line 630 "src/parser.y" /* yacc.c:1646  */
+#line 637 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_call("recurse", gen_noop());
 }
-#line 2987 "src/parser.c" /* yacc.c:1646  */
+#line 2996 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 74:
-#line 633 "src/parser.y" /* yacc.c:1646  */
+#line 640 "src/parser.y" /* yacc.c:1666  */
     {
   jv v = jv_string_fmt("*label-%s", jv_string_value((yyvsp[0].literal)));     // impossible symbol
   (yyval.blk) = gen_location((yyloc), locations,
@@ -2996,231 +3005,231 @@ yyreduce:
   jv_free(v);
   jv_free((yyvsp[0].literal));
 }
-#line 3000 "src/parser.c" /* yacc.c:1646  */
+#line 3009 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 75:
-#line 641 "src/parser.y" /* yacc.c:1646  */
+#line 648 "src/parser.y" /* yacc.c:1666  */
     {
   FAIL((yyloc), "break requires a label to break to");
   (yyval.blk) = gen_noop();
 }
-#line 3009 "src/parser.c" /* yacc.c:1646  */
+#line 3018 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 76:
-#line 645 "src/parser.y" /* yacc.c:1646  */
+#line 652 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index_opt((yyvsp[-2].blk), gen_const((yyvsp[-1].literal)));
 }
-#line 3017 "src/parser.c" /* yacc.c:1646  */
+#line 3026 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 77:
-#line 648 "src/parser.y" /* yacc.c:1646  */
+#line 655 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index_opt(gen_noop(), gen_const((yyvsp[-1].literal)));
 }
-#line 3025 "src/parser.c" /* yacc.c:1646  */
+#line 3034 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 78:
-#line 651 "src/parser.y" /* yacc.c:1646  */
+#line 658 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index_opt((yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 3033 "src/parser.c" /* yacc.c:1646  */
+#line 3042 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 79:
-#line 654 "src/parser.y" /* yacc.c:1646  */
+#line 661 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index_opt(gen_noop(), (yyvsp[-1].blk));
 }
-#line 3041 "src/parser.c" /* yacc.c:1646  */
+#line 3050 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 80:
-#line 657 "src/parser.y" /* yacc.c:1646  */
+#line 664 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index((yyvsp[-1].blk), gen_const((yyvsp[0].literal)));
 }
-#line 3049 "src/parser.c" /* yacc.c:1646  */
+#line 3058 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 81:
-#line 660 "src/parser.y" /* yacc.c:1646  */
+#line 667 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index(gen_noop(), gen_const((yyvsp[0].literal)));
 }
-#line 3057 "src/parser.c" /* yacc.c:1646  */
+#line 3066 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 82:
-#line 663 "src/parser.y" /* yacc.c:1646  */
+#line 670 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3065 "src/parser.c" /* yacc.c:1646  */
+#line 3074 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 83:
-#line 666 "src/parser.y" /* yacc.c:1646  */
+#line 673 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index(gen_noop(), (yyvsp[0].blk));
 }
-#line 3073 "src/parser.c" /* yacc.c:1646  */
+#line 3082 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 84:
-#line 669 "src/parser.y" /* yacc.c:1646  */
+#line 676 "src/parser.y" /* yacc.c:1666  */
     {
   FAIL((yyloc), "try .[\"field\"] instead of .field for unusually named fields");
   (yyval.blk) = gen_noop();
 }
-#line 3082 "src/parser.c" /* yacc.c:1646  */
+#line 3091 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 85:
-#line 673 "src/parser.y" /* yacc.c:1646  */
+#line 680 "src/parser.y" /* yacc.c:1666  */
     {
   jv_free((yyvsp[-1].literal));
   FAIL((yyloc), "try .[\"field\"] instead of .field for unusually named fields");
   (yyval.blk) = gen_noop();
 }
-#line 3092 "src/parser.c" /* yacc.c:1646  */
+#line 3101 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 86:
-#line 679 "src/parser.y" /* yacc.c:1646  */
+#line 686 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index_opt((yyvsp[-4].blk), (yyvsp[-2].blk));
 }
-#line 3100 "src/parser.c" /* yacc.c:1646  */
+#line 3109 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 87:
-#line 682 "src/parser.y" /* yacc.c:1646  */
+#line 689 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_index((yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 3108 "src/parser.c" /* yacc.c:1646  */
+#line 3117 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 88:
-#line 685 "src/parser.y" /* yacc.c:1646  */
+#line 692 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = block_join((yyvsp[-3].blk), gen_op_simple(EACH_OPT));
 }
-#line 3116 "src/parser.c" /* yacc.c:1646  */
+#line 3125 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 89:
-#line 688 "src/parser.y" /* yacc.c:1646  */
+#line 695 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = block_join((yyvsp[-2].blk), gen_op_simple(EACH));
 }
-#line 3124 "src/parser.c" /* yacc.c:1646  */
+#line 3133 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 90:
-#line 691 "src/parser.y" /* yacc.c:1646  */
+#line 698 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_slice_index((yyvsp[-6].blk), (yyvsp[-4].blk), (yyvsp[-2].blk), INDEX_OPT);
 }
-#line 3132 "src/parser.c" /* yacc.c:1646  */
+#line 3141 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 91:
-#line 694 "src/parser.y" /* yacc.c:1646  */
+#line 701 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_slice_index((yyvsp[-5].blk), (yyvsp[-3].blk), gen_const(jv_null()), INDEX_OPT);
 }
-#line 3140 "src/parser.c" /* yacc.c:1646  */
+#line 3149 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 92:
-#line 697 "src/parser.y" /* yacc.c:1646  */
+#line 704 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_slice_index((yyvsp[-5].blk), gen_const(jv_null()), (yyvsp[-2].blk), INDEX_OPT);
 }
-#line 3148 "src/parser.c" /* yacc.c:1646  */
+#line 3157 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 93:
-#line 700 "src/parser.y" /* yacc.c:1646  */
+#line 707 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_slice_index((yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk), INDEX);
 }
-#line 3156 "src/parser.c" /* yacc.c:1646  */
+#line 3165 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 94:
-#line 703 "src/parser.y" /* yacc.c:1646  */
+#line 710 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_slice_index((yyvsp[-4].blk), (yyvsp[-2].blk), gen_const(jv_null()), INDEX);
 }
-#line 3164 "src/parser.c" /* yacc.c:1646  */
+#line 3173 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 95:
-#line 706 "src/parser.y" /* yacc.c:1646  */
+#line 713 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_slice_index((yyvsp[-4].blk), gen_const(jv_null()), (yyvsp[-1].blk), INDEX);
 }
-#line 3172 "src/parser.c" /* yacc.c:1646  */
+#line 3181 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 96:
-#line 709 "src/parser.y" /* yacc.c:1646  */
+#line 716 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_const((yyvsp[0].literal));
 }
-#line 3180 "src/parser.c" /* yacc.c:1646  */
+#line 3189 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 97:
-#line 712 "src/parser.y" /* yacc.c:1646  */
+#line 719 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3188 "src/parser.c" /* yacc.c:1646  */
+#line 3197 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 98:
-#line 715 "src/parser.y" /* yacc.c:1646  */
+#line 722 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_format(gen_noop(), (yyvsp[0].literal));
 }
-#line 3196 "src/parser.c" /* yacc.c:1646  */
+#line 3205 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 99:
-#line 718 "src/parser.y" /* yacc.c:1646  */
+#line 725 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[-1].blk);
 }
-#line 3204 "src/parser.c" /* yacc.c:1646  */
+#line 3213 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 100:
-#line 721 "src/parser.y" /* yacc.c:1646  */
+#line 728 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_collect((yyvsp[-1].blk));
 }
-#line 3212 "src/parser.c" /* yacc.c:1646  */
+#line 3221 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 101:
-#line 724 "src/parser.y" /* yacc.c:1646  */
+#line 731 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_const(jv_array());
 }
-#line 3220 "src/parser.c" /* yacc.c:1646  */
+#line 3229 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 102:
-#line 727 "src/parser.y" /* yacc.c:1646  */
+#line 734 "src/parser.y" /* yacc.c:1666  */
     {
   block o = gen_const_object((yyvsp[-1].blk));
   if (o.first != NULL)
@@ -3228,29 +3237,29 @@ yyreduce:
   else
     (yyval.blk) = BLOCK(gen_subexp(gen_const(jv_object())), (yyvsp[-1].blk), gen_op_simple(POP));
 }
-#line 3232 "src/parser.c" /* yacc.c:1646  */
+#line 3241 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 103:
-#line 734 "src/parser.y" /* yacc.c:1646  */
+#line 741 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_const(JV_OBJECT(jv_string("file"), jv_copy(locations->fname),
                            jv_string("line"), jv_number(locfile_get_line(locations, (yyloc).start) + 1)));
 }
-#line 3241 "src/parser.c" /* yacc.c:1646  */
+#line 3250 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 104:
-#line 738 "src/parser.y" /* yacc.c:1646  */
+#line 745 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[0].literal))));
   jv_free((yyvsp[0].literal));
 }
-#line 3250 "src/parser.c" /* yacc.c:1646  */
+#line 3259 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 105:
-#line 742 "src/parser.y" /* yacc.c:1646  */
+#line 749 "src/parser.y" /* yacc.c:1666  */
     {
   const char *s = jv_string_value((yyvsp[0].literal));
   if (strcmp(s, "false") == 0)
@@ -3263,198 +3272,198 @@ yyreduce:
     (yyval.blk) = gen_location((yyloc), locations, gen_call(s, gen_noop()));
   jv_free((yyvsp[0].literal));
 }
-#line 3267 "src/parser.c" /* yacc.c:1646  */
+#line 3276 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 106:
-#line 754 "src/parser.y" /* yacc.c:1646  */
+#line 761 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_call(jv_string_value((yyvsp[-3].literal)), (yyvsp[-1].blk));
   (yyval.blk) = gen_location((yylsp[-3]), locations, (yyval.blk));
   jv_free((yyvsp[-3].literal));
 }
-#line 3277 "src/parser.c" /* yacc.c:1646  */
+#line 3286 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 107:
-#line 759 "src/parser.y" /* yacc.c:1646  */
+#line 766 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk) = gen_noop(); }
-#line 3283 "src/parser.c" /* yacc.c:1646  */
+#line 3292 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 108:
-#line 760 "src/parser.y" /* yacc.c:1646  */
+#line 767 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk) = gen_noop(); }
-#line 3289 "src/parser.c" /* yacc.c:1646  */
+#line 3298 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 109:
-#line 761 "src/parser.y" /* yacc.c:1646  */
+#line 768 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk) = (yyvsp[-3].blk); }
-#line 3295 "src/parser.c" /* yacc.c:1646  */
+#line 3304 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 110:
-#line 762 "src/parser.y" /* yacc.c:1646  */
+#line 769 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk) = gen_noop(); }
-#line 3301 "src/parser.c" /* yacc.c:1646  */
+#line 3310 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 111:
-#line 765 "src/parser.y" /* yacc.c:1646  */
+#line 772 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3309 "src/parser.c" /* yacc.c:1646  */
+#line 3318 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 112:
-#line 768 "src/parser.y" /* yacc.c:1646  */
+#line 775 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3317 "src/parser.c" /* yacc.c:1646  */
+#line 3326 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 113:
-#line 773 "src/parser.y" /* yacc.c:1646  */
+#line 780 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_lambda((yyvsp[0].blk));
 }
-#line 3325 "src/parser.c" /* yacc.c:1646  */
+#line 3334 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 114:
-#line 778 "src/parser.y" /* yacc.c:1646  */
+#line 785 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), gen_destructure_alt((yyvsp[0].blk)));
 }
-#line 3333 "src/parser.c" /* yacc.c:1646  */
+#line 3342 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 115:
-#line 781 "src/parser.y" /* yacc.c:1646  */
+#line 788 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_destructure_alt((yyvsp[0].blk));
 }
-#line 3341 "src/parser.c" /* yacc.c:1646  */
+#line 3350 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 116:
-#line 786 "src/parser.y" /* yacc.c:1646  */
+#line 793 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3349 "src/parser.c" /* yacc.c:1646  */
+#line 3358 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 117:
-#line 789 "src/parser.y" /* yacc.c:1646  */
+#line 796 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3357 "src/parser.c" /* yacc.c:1646  */
+#line 3366 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 118:
-#line 794 "src/parser.y" /* yacc.c:1646  */
+#line 801 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_op_unbound(STOREV, jv_string_value((yyvsp[0].literal)));
   jv_free((yyvsp[0].literal));
 }
-#line 3366 "src/parser.c" /* yacc.c:1646  */
+#line 3375 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 119:
-#line 798 "src/parser.y" /* yacc.c:1646  */
+#line 805 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-1].blk), gen_op_simple(POP));
 }
-#line 3374 "src/parser.c" /* yacc.c:1646  */
+#line 3383 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 120:
-#line 801 "src/parser.y" /* yacc.c:1646  */
+#line 808 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-1].blk), gen_op_simple(POP));
 }
-#line 3382 "src/parser.c" /* yacc.c:1646  */
+#line 3391 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 121:
-#line 806 "src/parser.y" /* yacc.c:1646  */
+#line 813 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_array_matcher(gen_noop(), (yyvsp[0].blk));
 }
-#line 3390 "src/parser.c" /* yacc.c:1646  */
+#line 3399 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 122:
-#line 809 "src/parser.y" /* yacc.c:1646  */
+#line 816 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_array_matcher((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3398 "src/parser.c" /* yacc.c:1646  */
+#line 3407 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 123:
-#line 814 "src/parser.y" /* yacc.c:1646  */
+#line 821 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3406 "src/parser.c" /* yacc.c:1646  */
+#line 3415 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 124:
-#line 817 "src/parser.y" /* yacc.c:1646  */
+#line 824 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3414 "src/parser.c" /* yacc.c:1646  */
+#line 3423 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 125:
-#line 822 "src/parser.y" /* yacc.c:1646  */
+#line 829 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[0].literal)), gen_op_unbound(STOREV, jv_string_value((yyvsp[0].literal))));
 }
-#line 3422 "src/parser.c" /* yacc.c:1646  */
+#line 3431 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 126:
-#line 825 "src/parser.y" /* yacc.c:1646  */
+#line 832 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[-2].literal)), BLOCK(gen_op_simple(DUP), gen_op_unbound(STOREV, jv_string_value((yyvsp[-2].literal))), (yyvsp[0].blk)));
 }
-#line 3430 "src/parser.c" /* yacc.c:1646  */
+#line 3439 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 127:
-#line 828 "src/parser.y" /* yacc.c:1646  */
+#line 835 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
 }
-#line 3438 "src/parser.c" /* yacc.c:1646  */
+#line 3447 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 128:
-#line 831 "src/parser.y" /* yacc.c:1646  */
+#line 838 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
 }
-#line 3446 "src/parser.c" /* yacc.c:1646  */
+#line 3455 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 129:
-#line 834 "src/parser.y" /* yacc.c:1646  */
+#line 841 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_object_matcher((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3454 "src/parser.c" /* yacc.c:1646  */
+#line 3463 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 130:
-#line 837 "src/parser.y" /* yacc.c:1646  */
+#line 844 "src/parser.y" /* yacc.c:1666  */
     {
   jv msg = check_object_key((yyvsp[-3].blk));
   if (jv_is_valid(msg)) {
@@ -3463,249 +3472,249 @@ yyreduce:
   jv_free(msg);
   (yyval.blk) = gen_object_matcher((yyvsp[-3].blk), (yyvsp[0].blk));
 }
-#line 3467 "src/parser.c" /* yacc.c:1646  */
+#line 3476 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 131:
-#line 845 "src/parser.y" /* yacc.c:1646  */
+#line 852 "src/parser.y" /* yacc.c:1666  */
     {
   FAIL((yyloc), "May need parentheses around object key expression");
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3476 "src/parser.c" /* yacc.c:1646  */
+#line 3485 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 132:
-#line 851 "src/parser.y" /* yacc.c:1646  */
+#line 858 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("as");
 }
-#line 3484 "src/parser.c" /* yacc.c:1646  */
+#line 3493 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 133:
-#line 854 "src/parser.y" /* yacc.c:1646  */
+#line 861 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("def");
 }
-#line 3492 "src/parser.c" /* yacc.c:1646  */
+#line 3501 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 134:
-#line 857 "src/parser.y" /* yacc.c:1646  */
+#line 864 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("module");
 }
-#line 3500 "src/parser.c" /* yacc.c:1646  */
+#line 3509 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 135:
-#line 860 "src/parser.y" /* yacc.c:1646  */
+#line 867 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("import");
 }
-#line 3508 "src/parser.c" /* yacc.c:1646  */
+#line 3517 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 136:
-#line 863 "src/parser.y" /* yacc.c:1646  */
+#line 870 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("include");
 }
-#line 3516 "src/parser.c" /* yacc.c:1646  */
+#line 3525 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 137:
-#line 866 "src/parser.y" /* yacc.c:1646  */
+#line 873 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("if");
 }
-#line 3524 "src/parser.c" /* yacc.c:1646  */
+#line 3533 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 138:
-#line 869 "src/parser.y" /* yacc.c:1646  */
+#line 876 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("then");
 }
-#line 3532 "src/parser.c" /* yacc.c:1646  */
+#line 3541 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 139:
-#line 872 "src/parser.y" /* yacc.c:1646  */
+#line 879 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("else");
 }
-#line 3540 "src/parser.c" /* yacc.c:1646  */
+#line 3549 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 140:
-#line 875 "src/parser.y" /* yacc.c:1646  */
+#line 882 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("elif");
 }
-#line 3548 "src/parser.c" /* yacc.c:1646  */
+#line 3557 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 141:
-#line 878 "src/parser.y" /* yacc.c:1646  */
+#line 885 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("reduce");
 }
-#line 3556 "src/parser.c" /* yacc.c:1646  */
+#line 3565 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 142:
-#line 881 "src/parser.y" /* yacc.c:1646  */
+#line 888 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("foreach");
 }
-#line 3564 "src/parser.c" /* yacc.c:1646  */
+#line 3573 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 143:
-#line 884 "src/parser.y" /* yacc.c:1646  */
+#line 891 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("end");
 }
-#line 3572 "src/parser.c" /* yacc.c:1646  */
+#line 3581 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 144:
-#line 887 "src/parser.y" /* yacc.c:1646  */
+#line 894 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("and");
 }
-#line 3580 "src/parser.c" /* yacc.c:1646  */
+#line 3589 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 145:
-#line 890 "src/parser.y" /* yacc.c:1646  */
+#line 897 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("or");
 }
-#line 3588 "src/parser.c" /* yacc.c:1646  */
+#line 3597 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 146:
-#line 893 "src/parser.y" /* yacc.c:1646  */
+#line 900 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("try");
 }
-#line 3596 "src/parser.c" /* yacc.c:1646  */
+#line 3605 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 147:
-#line 896 "src/parser.y" /* yacc.c:1646  */
+#line 903 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("catch");
 }
-#line 3604 "src/parser.c" /* yacc.c:1646  */
+#line 3613 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 148:
-#line 899 "src/parser.y" /* yacc.c:1646  */
+#line 906 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("label");
 }
-#line 3612 "src/parser.c" /* yacc.c:1646  */
+#line 3621 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 149:
-#line 902 "src/parser.y" /* yacc.c:1646  */
+#line 909 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("break");
 }
-#line 3620 "src/parser.c" /* yacc.c:1646  */
+#line 3629 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 150:
-#line 905 "src/parser.y" /* yacc.c:1646  */
+#line 912 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.literal) = jv_string("__loc__");
 }
-#line 3628 "src/parser.c" /* yacc.c:1646  */
+#line 3637 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 151:
-#line 910 "src/parser.y" /* yacc.c:1646  */
+#line 917 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk)=gen_noop();
 }
-#line 3636 "src/parser.c" /* yacc.c:1646  */
+#line 3645 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 152:
-#line 913 "src/parser.y" /* yacc.c:1646  */
+#line 920 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk) = (yyvsp[0].blk); }
-#line 3642 "src/parser.c" /* yacc.c:1646  */
+#line 3651 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 153:
-#line 914 "src/parser.y" /* yacc.c:1646  */
+#line 921 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk)=block_join((yyvsp[-2].blk), (yyvsp[0].blk)); }
-#line 3648 "src/parser.c" /* yacc.c:1646  */
+#line 3657 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 154:
-#line 915 "src/parser.y" /* yacc.c:1646  */
+#line 922 "src/parser.y" /* yacc.c:1666  */
     { (yyval.blk) = (yyvsp[0].blk); }
-#line 3654 "src/parser.c" /* yacc.c:1646  */
+#line 3663 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 155:
-#line 918 "src/parser.y" /* yacc.c:1646  */
+#line 925 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
  }
-#line 3662 "src/parser.c" /* yacc.c:1646  */
+#line 3671 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 156:
-#line 921 "src/parser.y" /* yacc.c:1646  */
+#line 928 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
   }
-#line 3670 "src/parser.c" /* yacc.c:1646  */
+#line 3679 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 157:
-#line 924 "src/parser.y" /* yacc.c:1646  */
+#line 931 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_dictpair((yyvsp[-2].blk), (yyvsp[0].blk));
   }
-#line 3678 "src/parser.c" /* yacc.c:1646  */
+#line 3687 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 158:
-#line 927 "src/parser.y" /* yacc.c:1646  */
+#line 934 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_dictpair((yyvsp[0].blk), BLOCK(gen_op_simple(POP), gen_op_simple(DUP2),
                               gen_op_simple(DUP2), gen_op_simple(INDEX)));
   }
-#line 3687 "src/parser.c" /* yacc.c:1646  */
+#line 3696 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 159:
-#line 931 "src/parser.y" /* yacc.c:1646  */
+#line 938 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[0].literal)),
                     gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[0].literal)))));
   }
-#line 3696 "src/parser.c" /* yacc.c:1646  */
+#line 3705 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 160:
-#line 935 "src/parser.y" /* yacc.c:1646  */
+#line 942 "src/parser.y" /* yacc.c:1666  */
     {
   (yyval.blk) = gen_dictpair(gen_const(jv_copy((yyvsp[0].literal))),
                     gen_index(gen_noop(), gen_const((yyvsp[0].literal))));
   }
-#line 3705 "src/parser.c" /* yacc.c:1646  */
+#line 3714 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 161:
-#line 939 "src/parser.y" /* yacc.c:1646  */
+#line 946 "src/parser.y" /* yacc.c:1666  */
     {
   jv msg = check_object_key((yyvsp[-3].blk));
   if (jv_is_valid(msg)) {
@@ -3714,20 +3723,20 @@ yyreduce:
   jv_free(msg);
   (yyval.blk) = gen_dictpair((yyvsp[-3].blk), (yyvsp[0].blk));
   }
-#line 3718 "src/parser.c" /* yacc.c:1646  */
+#line 3727 "src/parser.c" /* yacc.c:1666  */
     break;
 
   case 162:
-#line 947 "src/parser.y" /* yacc.c:1646  */
+#line 954 "src/parser.y" /* yacc.c:1666  */
     {
   FAIL((yyloc), "May need parentheses around object key expression");
   (yyval.blk) = (yyvsp[0].blk);
   }
-#line 3727 "src/parser.c" /* yacc.c:1646  */
+#line 3736 "src/parser.c" /* yacc.c:1666  */
     break;
 
 
-#line 3731 "src/parser.c" /* yacc.c:1646  */
+#line 3740 "src/parser.c" /* yacc.c:1666  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -3850,7 +3859,6 @@ yyerrorlab:
   if (/*CONSTCOND*/ 0)
      goto yyerrorlab;
 
-  yyerror_range[1] = yylsp[1-yylen];
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
@@ -3962,7 +3970,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 951 "src/parser.y" /* yacc.c:1906  */
+#line 958 "src/parser.y" /* yacc.c:1910  */
 
 
 int jq_parse(struct locfile* locations, block* answer) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.1.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@
 extern int yydebug;
 #endif
 /* "%code requires" blocks.  */
-#line 11 "src/parser.y" /* yacc.c:1909  */
+#line 11 "src/parser.y" /* yacc.c:1919  */
 
 #include "locfile.h"
 struct lexer_param;
@@ -57,7 +57,7 @@ struct lexer_param;
     }                                           \
   } while (0)
 
-#line 61 "src/parser.h" /* yacc.c:1909  */
+#line 61 "src/parser.h" /* yacc.c:1919  */
 
 /* Token type.  */
 #ifndef YYTOKENTYPE
@@ -163,12 +163,12 @@ struct lexer_param;
 
 union YYSTYPE
 {
-#line 31 "src/parser.y" /* yacc.c:1909  */
+#line 31 "src/parser.y" /* yacc.c:1919  */
 
   jv literal;
   block blk;
 
-#line 172 "src/parser.h" /* yacc.c:1909  */
+#line 172 "src/parser.h" /* yacc.c:1919  */
 };
 
 typedef union YYSTYPE YYSTYPE;

--- a/src/parser.y
+++ b/src/parser.y
@@ -216,19 +216,26 @@ static block constant_fold(block a, block b, int op) {
   jv res = jv_invalid();
 
   if (block_const_kind(a) == JV_KIND_NUMBER) {
-    double na = jv_number_value(block_const(a));
-    double nb = jv_number_value(block_const(b));
+    jv jv_a = block_const(a);
+    jv jv_b = block_const(b);
+
+    double na = jv_number_value(jv_a);
+    double nb = jv_number_value(jv_b);
+
+    // consumes the numbers
+    int equal = jv_equal(jv_a, jv_b);
+
     switch (op) {
     case '+': res = jv_number(na + nb); break;
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;
-    case EQ:  res = (na == nb ? jv_true() : jv_false()); break;
-    case NEQ: res = (na != nb ? jv_true() : jv_false()); break;
+    case EQ:  res = (equal ? jv_true() : jv_false()); break;
+    case NEQ: res = (!equal ? jv_true() : jv_false()); break;
     case '<': res = (na < nb ? jv_true() : jv_false()); break;
     case '>': res = (na > nb ? jv_true() : jv_false()); break;
-    case LESSEQ: res = (na <= nb ? jv_true() : jv_false()); break;
-    case GREATEREQ: res = (na >= nb ? jv_true() : jv_false()); break;
+    case LESSEQ: res = ((equal || (na <= nb)) ? jv_true() : jv_false()); break;
+    case GREATEREQ: res = ((equal || (na >= nb)) ? jv_true() : jv_false()); break;
     default: break;
     }
   } else if (op == '+' && block_const_kind(a) == JV_KIND_STRING) {

--- a/src/parser.y
+++ b/src/parser.y
@@ -222,20 +222,20 @@ static block constant_fold(block a, block b, int op) {
     double na = jv_number_value(jv_a);
     double nb = jv_number_value(jv_b);
 
-    // consumes the numbers
-    int equal = jv_equal(jv_a, jv_b);
+    jv_free(jv_a);
+    jv_free(jv_b);
 
     switch (op) {
     case '+': res = jv_number(na + nb); break;
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;
-    case EQ:  res = (equal ? jv_true() : jv_false()); break;
-    case NEQ: res = (!equal ? jv_true() : jv_false()); break;
+    case EQ:  res = (na == nb ? jv_true() : jv_false()); break;
+    case NEQ: res = (na != nb ? jv_true() : jv_false()); break;
     case '<': res = (na < nb ? jv_true() : jv_false()); break;
     case '>': res = (na > nb ? jv_true() : jv_false()); break;
-    case LESSEQ: res = ((equal || (na <= nb)) ? jv_true() : jv_false()); break;
-    case GREATEREQ: res = ((equal || (na >= nb)) ? jv_true() : jv_false()); break;
+    case LESSEQ: res = (na <= nb ? jv_true() : jv_false()); break;
+    case GREATEREQ: res = (na >= nb ? jv_true() : jv_false()); break;
     default: break;
     }
   } else if (op == '+' && block_const_kind(a) == JV_KIND_STRING) {

--- a/src/parser.y
+++ b/src/parser.y
@@ -172,7 +172,7 @@ static jv check_object_key(block k) {
     char errbuf[15];
     return jv_string_fmt("Cannot use %s (%s) as object key",
         jv_kind_name(block_const_kind(k)),
-        jv_dump_string_trunc(jv_copy(block_const(k)), errbuf, sizeof(errbuf)));
+        jv_dump_string_trunc(block_const(k), errbuf, sizeof(errbuf)));
   }
   return jv_invalid();
 }

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -540,8 +540,8 @@ null
 {"object": {"a":42}, "num":10.0}
 [true,  true,  false, false, false, false, false, false, false]
 [true,  true,  false, false, false, false, false, false, false]
-[false, false, true,  false, false, false, false, false, false]
-[false, false, false, true,  false, false, false, false, false]
+[false, false, true,  true,  false, false, false, false, false]
+[false, false, true,  true,  false, false, false, false, false]
 [false, false, false, false, true,  false, false, false, false]
 [false, false, false, false, false, true,  false, false, false]
 [false, false, false, false, false, false, true,  false, false]
@@ -1522,19 +1522,25 @@ false
 # For an example see #1652 and other linked issues
 #
 
+# We care about backward compatibility! 
+
+1.0 == 1.00
+null
+true
+
 # When no arithmetic is involved jq should preserve the literal value
 
-.
+literal(.)
 13911860366432393
-13911860366432393
+"13911860366432393"
 
-.[0]
+.[0] | tostring
 [13911860366432393]
-13911860366432393
+"13911860366432393"
 
-.x
+.x | tojson
 {"x":13911860366432393}
-13911860366432393
+"13911860366432393"
 
 
 # Applying arithmetic to the value will truncate the result to double
@@ -1550,4 +1556,18 @@ false
 .x - 10
 {"x":13911860366432393}
 13911860366432382
+
+13911860366432393 == 13911860366432392
+null
+true
+
+# literal(x) should fail for arrays, objects and calculated numbers
+
+[1e+12345, 1+1, {}, []] | map(try literal(.) catch .)[]
+null
+"1e+12345"
+"literal value is not available for a calculated number"
+"object ({}) isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal"
+"array ([]) isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal"
+
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1522,11 +1522,11 @@ false
 # For an example see #1652 and other linked issues
 #
 
-# We care about backward compatibility! 
+# We are backward and sanity compatible
 
-1.0 == 1.00
-null
-true
+map(. == 1)
+[1, 1.0, 1.000, 100e-2, 1e+0, 0.0001e4]
+[true, true, true, true, true, true]
 
 # When no arithmetic is involved jq should preserve the literal value
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -540,8 +540,8 @@ null
 {"object": {"a":42}, "num":10.0}
 [true,  true,  false, false, false, false, false, false, false]
 [true,  true,  false, false, false, false, false, false, false]
-[false, false, true,  true,  false, false, false, false, false]
-[false, false, true,  true,  false, false, false, false, false]
+[false, false, true,  false, false, false, false, false, false]
+[false, false, false, true,  false, false, false, false, false]
 [false, false, false, false, true,  false, false, false, false]
 [false, false, false, false, false, true,  false, false, false]
 [false, false, false, false, false, false, true,  false, false]
@@ -1516,4 +1516,38 @@ isempty(1,error("foo"))
 null
 false
 
+
+#
+# Tests to cover the new literal number functionality
+# For an example see #1652 and other linked issues
+#
+
+# When no arithmetic is involved jq should preserve the literal value
+
+.
+13911860366432393
+13911860366432393
+
+.[0]
+[13911860366432393]
+13911860366432393
+
+.x
+{"x":13911860366432393}
+13911860366432393
+
+
+# Applying arithmetic to the value will truncate the result to double
+
+. - 10
+13911860366432393
+13911860366432382
+
+.[0] - 10
+[13911860366432393]
+13911860366432382
+
+.x - 10
+{"x":13911860366432393}
+13911860366432382
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1518,7 +1518,7 @@ false
 
 
 #
-# Tests to cover the new literal number functionality
+# Tests to cover the new toliteral number functionality
 # For an example see #1652 and other linked issues
 #
 
@@ -1530,7 +1530,7 @@ true
 
 # When no arithmetic is involved jq should preserve the literal value
 
-literal(.)
+toliteral
 13911860366432393
 "13911860366432393"
 
@@ -1561,9 +1561,9 @@ literal(.)
 null
 true
 
-# literal(x) should fail for arrays, objects and calculated numbers
+# (x | toliteral) should fail for arrays, objects and calculated numbers
 
-[1e+12345, 1+1, {}, []] | map(try literal(.) catch .)[]
+[1e+12345, 1+1, {}, []] | map(try (. | toliteral) catch .)[]
 null
 "1e+12345"
 "literal value is not available for a calculated number"

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1563,11 +1563,12 @@ true
 
 # (x | toliteral) should fail for arrays, objects and calculated numbers
 
-[1e+12345, 1+1, {}, []] | map(try (. | toliteral) catch .)[]
+[1e+12345, 1+1, {}, [], nan, infinite] | map(try (. | toliteral) catch .)[]
 null
 "1e+12345"
-"literal value is not available for a calculated number"
+"literal value is not available for a calculated number, infinite number or a NaN"
 "object ({}) isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal"
 "array ([]) isn't a simple type; only string, null, true, false and non calculated numbers can produce a literal"
-
+"literal value is not available for a calculated number, infinite number or a NaN"
+"literal value is not available for a calculated number, infinite number or a NaN"
 

--- a/tests/local.supp
+++ b/tests/local.supp
@@ -1,0 +1,14 @@
+{
+   macos valgrind 1
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:map_images_nolock
+   ...
+   fun:_dyld_objc_notify_register
+   fun:_objc_init
+   fun:_os_object_init
+   fun:libdispatch_init
+   fun:libSystem_initializer
+   ...
+}

--- a/tests/setup
+++ b/tests/setup
@@ -14,7 +14,8 @@ JQ=$JQBASEDIR/jq
 
 if [ -z "${NO_VALGRIND-}" ] && which valgrind > /dev/null; then
     VALGRIND="valgrind --error-exitcode=1 --leak-check=full \
-                       --suppressions=$JQTESTDIR/onig.supp"
+                       --suppressions=$JQTESTDIR/onig.supp \
+                       --suppressions=$JQTESTDIR/local.supp"
     VG_EXIT0=--error-exitcode=0
     Q=-q
 else


### PR DESCRIPTION
This is a POC implementation of a concept which may resolve numerous cases of truncated integer identifiers due to the double limitation reported by #1652

The logic is pretty simple: for every parsed number we store the actual read literal which was used to generate the double representation. Then, we use this literal for comparisons and printing.
Any math operation on the literal number will use the truncated double precision representation and generate a new `jv_number` with no literal associated.

The implementation is trying to make minimal impact on the performance by falling back to the original number representation whenever literal information is not available.

This implementation has a side effect of non equivalence of `10` and `10.0`, which could be taken as a neat feature, or as a bug. Anyhow, it will definitely be considered a non backward compatible change :/. This is clearly seen in the need to update a test on line 539.

However, this particular aspect can be adjusted, as the equivalence operation may be considered "math" in terms that the double representation of the number will be taken. 
This will make it backward compatible, but I believe that this literal equivalence must be preserved. If we take the use case of some external database ID then it would be great if jq could also match those ids, not only preserve in the output unchanged.

A fun fact about this branch is that the tests to verify the new functionality depend on the functionality itself. As it turned out, the test suite is utilising the same parsing routines to compare the actual output to the expected output, so the truncation test cases actually succeed on the master branch where the testing code is unable to see the difference between those large numbers.

