### PR TITLE
Fix for missing directory bdir/src

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,10 +97,12 @@ generate_ver = ver="`{ $(srcdir)/scripts/version || echo '$(VERSION)' ; } | sed 
 .remake-version-h: .FORCE
 	@ $(generate_ver); test "x`cat src/version.h 2>/dev/null`" = "x$$ver" || touch .remake-version-h
 src/version.h: .remake-version-h
+	mkdir -p src
 	$(AM_V_GEN) $(generate_ver); echo "$$ver" > $@
 src/main.c: src/version.h
 
 src/builtin.inc: src/builtin.jq
+	mkdir -p src
 	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $^ > $@
 src/builtin.o: src/builtin.inc
 


### PR DESCRIPTION
This occurs given:

* out-of-source-build: (eg. building in the directory `build`) since `${build-dir}/src` is not present
* `--disable-dependency-tracking`: the ${build-dir}/src is not created since it's unneeded

As a result, the `${build-dir}/src` is absent.
Then, the shell output redirection fails.

This patch `mkdir -p` in advance of the redirection output.