### PR TITLE
Make fromstream/1 more efficient

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -217,22 +217,25 @@ def ascii_upcase:
 def truncate_stream(stream):
   . as $n | null | stream | . as $input | if (.[0]|length) > $n then setpath([0];$input[0][$n:]) else empty end;
 def fromstream(i):
-  foreach i as $item (
-    [null,false,null,false];
-    if ($item[0]|length) == 0 then [null,false,.[2],.[3]]
-    elif ($item|length) == 1 and ($item[0]|length) < 2 then [null,false,.[0],.[1]]
-    else . end |
-    . as $state |
-    if ($item|length) > 1 and ($item[0]|length) > 0 then
-      [.[0]|setpath(($item|.[0]); ($item|.[1])),
-      true,
-      $state[2],
-      $state[3]]
+  foreach i as $i (
+    [null, null];
+
+    if ($i | length) == 2 then
+      if ($i[0] | length) == 0 then .
+      else [ ( .[0] | setpath($i[0]; $i[1]) ), .[1] ]
+      end
+    elif ($i[0] | length) == 1 then [ null, .[0] ]
     else .
     end;
-    if ($item[0]|length) == 1 and ($item|length == 1) and .[3] then .[2] else empty end,
-    if ($item[0]|length) == 0 then $item[1] else empty end
-    );
+
+    if ($i | length) == 1 then
+      if ($i[0] | length) == 1 then .[1]
+      else empty
+      end
+    elif ($i[0] | length) == 0 then $i[1]
+    else empty
+    end
+  );
 def tostream:
   {string:true,number:true,boolean:true,null:true} as $leaf_types |
   . as $dot |


### PR DESCRIPTION
Hi all,

it looks like I was able to make `fromstream/1` about 30% faster.

I could not find complete definition of the stream output, so I assume we only have the following input forms:
```
1. [[], v]     : scalar value or empty array/object at root level (empty path, value present)
2. [[p+], v]   : scalar value or empty array/object at nested level (non-empty path, value present)
3. [[p+]]      : end of an array/object at nested level (non-empty path, value absent)
4. [[p]]       : end of an array/object at root level (one-length path, value absent)
```
To be able to reconstruct JSON structures we are only interested in 3 of these cases:
1. In this case we do not need to update the state, we can emit the value directly.
2. Here we only update currently reconstructed array/object and do not emit anything.
3. Do nothing here.
4. Special case: Initialize the state for next cycle and emit finished JSON structure.

Since "extract" is always executed after "update", we need a two-slot state:
state[0]: working area
state[1]: finished area
Every time we receive the input form described in 4, in "update" step we move state[0] to state[1] and initialize state[0] with null. Then in "extract" step we simply emit the content of state[1].

I assume the length of each stream row is always one or two. I tried to use only equality checks, since I noticed, that all other checks (less/greater compare or non-equal) seem to be slower. I also tried to balance the if paths so we never need to execute more than two checks to be able to decide.

Tested on a prepared stream (6000000 lines, ~108M) of 1000000 JSON objects like:
```
{"id":"STRING-0","key":["STRING",0],"value":0}
```
Disabled output to reduce IO time.

Performance win about 30%:
```
+ jq -nc 'fromstream(inputs) | empty' stream.json

real    1m26.141s
user    0m0.000s
sys     0m0.015s

+ jq -nc 'fromstream2(inputs) | empty' stream.json

real    1m0.001s
user    0m0.015s
sys     0m0.000s
```