### PR TITLE
add automake as build dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Source tarball and built executable releases can be found on the
 homepage and on the github release page, https://github.com/stedolan/jq/releases
 
 If you're building directly from the latest git, you'll need flex,
-bison (3.0 or newer), libtool, make, and autoconf installed.
+bison (3.0 or newer), libtool, make, automake, and autoconf installed.
 To get regexp support you'll also need to install Oniguruma or clone it as a
 git submodule as per the instructions below.
 (note that jq's tests require regexp support to pass).  To build, run:


### PR DESCRIPTION
When I tried to build jq on my MacBook Pro with macOS 10.14.1 following instructions in README.md, `./configure` gives the following error:

```
Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory
```

which can be solved by installing `automake`.

Thus I suggest to add a mention of automake as build dependency in the README.md