### PR TITLE
fix comparison of integers of different signs warning

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1497,7 +1497,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) (yyg->yy_n_chars + number_to_move) > (int) (YY_CURRENT_BUFFER_LVALUE->yy_buf_size)) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) jq_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );


### PR DESCRIPTION
Building on macOS emits the following warning so I fixed by casting to int.
```
src/lexer.c:1500:47: warning: comparison of integers of different signs: 'int' and 'yy_size_t' (aka 'unsigned long') [-Wsign-compare]
        if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```