### PR TITLE
Fix build on BSD make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ src/main.c: src/version.h
 
 src/builtin.inc: src/builtin.jq
 	mkdir -p src
-	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $^ > $@
+	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' src/builtin.jq > $@
 src/builtin.o: src/builtin.inc
 
 bin_PROGRAMS = jq
@@ -135,10 +135,10 @@ if ENABLE_DOCS
 jq.1: $(srcdir)/docs/content/3.manual/manual.yml
 	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; '$(BUNDLER)' exec rake manpage ) > $@ || { rm -f $@; false; }
 jq.1.prebuilt: jq.1
-	$(AM_V_GEN) cp $^ $@ || { rm -f $@; false; }
+	$(AM_V_GEN) cp jq.1 $@ || { rm -f $@; false; }
 else
 jq.1: $(srcdir)/jq.1.prebuilt
-	$(AM_V_GEN) cp $^ $@
+	$(AM_V_GEN) cp $(srcdir)/jq.1.prebuilt $@
 endif
 
 


### PR DESCRIPTION
Replace uses of the nonstandard $^ variable by explicitly specifying the
source filenames. This is the only obvious thing preventing the build
from running correctly on non-GNU make.