### PR TITLE
Define error/1 in terms of error/0

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1056,9 +1056,8 @@ static jv f_nan(jq_state *jq, jv input) {
   return jv_number(NAN);
 }
 
-static jv f_error(jq_state *jq, jv input, jv msg) {
-  jv_free(input);
-  return jv_invalid_with_msg(msg);
+static jv f_error(jq_state *jq, jv input) {
+  return jv_invalid_with_msg(input);
 }
 
 // FIXME Should autoconf check for this!
@@ -1653,7 +1652,7 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_max, "max", 1},
   {(cfunction_ptr)f_min_by_impl, "_min_by_impl", 2},
   {(cfunction_ptr)f_max_by_impl, "_max_by_impl", 2},
-  {(cfunction_ptr)f_error, "error", 2},
+  {(cfunction_ptr)f_error, "error", 1},
   {(cfunction_ptr)f_format, "format", 2},
   {(cfunction_ptr)f_env, "env", 1},
   {(cfunction_ptr)f_halt, "halt", 1},

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -1,5 +1,5 @@
 def halt_error: halt_error(5);
-def error: error(.);
+def error(msg): msg|error;
 def map(f): [.[] | f];
 def select(f): if f then . else empty end;
 def sort_by(f): _sort_by_impl(map([f]));


### PR DESCRIPTION
The parser generates a call to error/0 on break. Having that exported
from C directly removes a language dependency on builtin.jq.

In any case, error/0 seems to be the more fundamental operation, seeing
as the old C impementation of error/1 did nothing useful with its input.