### PR TITLE
 Work around fgets()'s lack of length reporting

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -10,7 +10,7 @@ def max_by(f): _max_by_impl(map([f]));
 def min_by(f): _min_by_impl(map([f]));
 def add: reduce .[] as $x (null; . + $x);
 def del(f): delpaths([path(f)]);
-def _assign(paths; value): value as $v | reduce path(paths) as $p (.; setpath($p; $v));
+def _assign(paths; $value): reduce path(paths) as $p (.; setpath($p; $value));
 def _modify(paths; update): reduce path(paths) as $p (.; label $out | (setpath($p; getpath($p) | update) | ., break $out), delpaths([$p]));
 def map_values(f): .[] |= f;
 


### PR DESCRIPTION
Stop losing \0s from the end of files because we don't know how much
fgets() read into our buffer. If we prefill the buffer with anything
other than zeroes, we can actually tell the difference between the
terminator and unused space in the buffer.

This is possibly more expensive, but at least it should be correct.

Fixes #1504