### PR TITLE
Bind data as $var when already resolved too

### DIFF
--- a/src/linker.c
+++ b/src/linker.c
@@ -263,26 +263,38 @@ static int process_dependencies(jq_state *jq, jv jq_origin, jv lib_origin, block
       jv_free(lib_origin);
       return 1;
     }
-    uint64_t state_idx = 0;
-    for (; state_idx < lib_state->ct; ++state_idx) {
-      if (strcmp(lib_state->names[state_idx],jv_string_value(resolved)) == 0)
-        break;
-    }
-    if (state_idx < lib_state->ct) { // Found
-      jv_free(resolved);
-      // Bind the library to the program
-      bk = block_bind_library(lib_state->defs[state_idx], bk, OP_IS_CALL_PSEUDO, as_str);
-    } else { // Not found.   Add it to the table before binding.
-      block dep_def_block = gen_noop();
+
+    if (is_data) {
+      // Can't reuse data libs because the wrong name is bound
+      block dep_def_block;
       nerrors += load_library(jq, resolved, is_data, raw, as_str, &dep_def_block, lib_state);
-      // resolved has been freed
       if (nerrors == 0) {
-        // Bind the library to the program
+        // Bind as both $data::data and $data for backward compatibility vs common sense
         bk = block_bind_library(dep_def_block, bk, OP_IS_CALL_PSEUDO, as_str);
-        if (is_data)
-          bk = block_bind_library(dep_def_block, bk, OP_IS_CALL_PSEUDO, NULL);
+        bk = block_bind_library(dep_def_block, bk, OP_IS_CALL_PSEUDO, NULL);
+      }
+    } else {
+      uint64_t state_idx = 0;
+      for (; state_idx < lib_state->ct; ++state_idx) {
+        if (strcmp(lib_state->names[state_idx],jv_string_value(resolved)) == 0)
+          break;
+      }
+
+      if (state_idx < lib_state->ct) { // Found
+        jv_free(resolved);
+        // Bind the library to the program
+        bk = block_bind_library(lib_state->defs[state_idx], bk, OP_IS_CALL_PSEUDO, as_str);
+      } else { // Not found.   Add it to the table before binding.
+        block dep_def_block = gen_noop();
+        nerrors += load_library(jq, resolved, is_data, raw, as_str, &dep_def_block, lib_state);
+        // resolved has been freed
+        if (nerrors == 0) {
+          // Bind the library to the program
+          bk = block_bind_library(dep_def_block, bk, OP_IS_CALL_PSEUDO, as_str);
+        }
       }
     }
+
     jv_free(as);
   }
   jv_free(lib_origin);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1392,6 +1392,10 @@ include "c"; [a, c]
 null
 [0,"acmehbah"]
 
+import "data" as $e; import "data" as $d; [$d[].this,$e[].that,$d::d[].this,$e::e[].that]|join(";")
+null
+"is a test;is too;is a test;is too"
+
 %%FAIL
 module (.+1); 0
 jq: error: Module metadata must be constant at <top-level>, line 1:


### PR DESCRIPTION
b5560d84 lets the data imported by `import "data" as $data` be accessed as either $data or $data::data, except that when "data" has already been imported before, it isn't bound to $data because that code isn't in the other if branch.