### PR TITLE
Attempt to improve linking time (#1380)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
                         - valgrind
                         - bison
                         - automake
+                        - git
 
             before_install:
                 - uname -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ jobs:
                 - uname -s
                 - brew update
                 - brew install flex bison
-                - rvm install ruby-1.9.3-p551
-                - rvm use 1.9.3
+                - rvm install ruby-2.3.0
+                - rvm use 2.3.0
                 - gem install bundler
                 - rm src/{lexer,parser}.{c,h}
                 - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac


### PR DESCRIPTION
Here's my stab at the linking problem. This is definitely a band-aid that doesn't solve the underlying issues, and the implementation is iffy.

The idea here is to mark whole definitions when all the symbols inside are bound, then avoid descending into them on later iterations.

It's still pretty far from ideal, but at least it manages to cut close to half the test suite runtime.