### PR TITLE
Make sure to free in jv_string_indexes

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -658,12 +658,12 @@ jv jv_string_indexes(jv j, jv k) {
   int idxlen = jv_string_length_bytes(jv_copy(k));
   jv a = jv_array();
 
-  if (idxlen == 0)
-    return a;
-  p = jstr;
-  while ((p = _jq_memmem(p, (jstr + jlen) - p, idxstr, idxlen)) != NULL) {
-    a = jv_array_append(a, jv_number(p - jstr));
-    p += idxlen;
+  if (idxlen != 0) {
+    p = jstr;
+    while ((p = _jq_memmem(p, (jstr + jlen) - p, idxstr, idxlen)) != NULL) {
+      a = jv_array_append(a, jv_number(p - jstr));
+      p += idxlen;
+    }
   }
   jv_free(j);
   jv_free(k);


### PR DESCRIPTION
2660b04a731568c54eb4b91fe811d81cbbf3470b makes jqtest fail valgrind since it skips the frees when idxlen == 0.

This was kind of an interesting experience when making other changes that could plausibly have leaked memory.