### PR TITLE
Load ~/.jq as a library

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -469,19 +469,16 @@ block block_drop_unreferenced(block body) {
 jv block_take_imports(block* body) {
   jv imports = jv_array();
 
-  inst* top = NULL;
-  if (body->first && body->first->op == TOP) {
-    top = block_take(body);
-  }
+  /* Parser should never generate TOP before imports */
+  assert(!(body->first && body->first->op == TOP && body->first->next &&
+        (body->first->next->op == MODULEMETA || body->first->next->op == DEPS)));
+
   while (body->first && (body->first->op == MODULEMETA || body->first->op == DEPS)) {
     inst* dep = block_take(body);
     if (dep->op == DEPS) {
       imports = jv_array_append(imports, jv_copy(dep->imm.constant));
     }
     inst_free(dep);
-  }
-  if (top) {
-    *body = block_join(inst_block(top),*body);
   }
   return imports;
 }

--- a/src/compile.c
+++ b/src/compile.c
@@ -317,20 +317,6 @@ static int block_count_actuals(block b) {
   return args;
 }
 
-static int block_count_refs(block binder, block body) {
-  int nrefs = 0;
-  for (inst* i = body.first; i; i = i->next) {
-    if (i != binder.first && i->bound_by == binder.first) {
-      nrefs++;
-    }
-    // counting recurses into closures
-    nrefs += block_count_refs(binder, i->subfn);
-    // counting recurses into argument list
-    nrefs += block_count_refs(binder, i->arglist);
-  }
-  return nrefs;
-}
-
 static int block_bind_subblock_inner(int* any_unbound, block binder, block body, int bindflags, int break_distance) {
   assert(block_is_single(binder));
   assert((opcode_describe(binder.first->op)->flags & bindflags) == (bindflags & ~OP_BIND_WILDCARD));
@@ -434,37 +420,18 @@ block block_bind_library(block binder, block body, int bindflags, const char *li
   return body; // We don't return a join because we don't want those sticking around...
 }
 
-// Bind binder to body and throw away any defs in binder not referenced
-// (directly or indirectly) from body.
+// Bind binder to body, then throw it away if not referenced.
 block block_bind_referenced(block binder, block body, int bindflags) {
+  assert(block_is_single(binder));
   assert(block_has_only_binders(binder, bindflags));
   bindflags |= OP_HAS_BINDING;
-  block refd = gen_noop();
-  block unrefd = gen_noop();
-  int nrefs;
-  for (int last_kept = 0, kept = 0; ; ) {
-    for (inst* curr; (curr = block_take(&binder));) {
-      block b = inst_block(curr);
-      nrefs = block_bind_each(b, body, bindflags);
-      // Check if this binder is referenced from any of the ones we
-      // already know are referenced by body.
-      nrefs += block_count_refs(b, refd);
-      nrefs += block_count_refs(b, body);
-      if (nrefs) {
-        refd = BLOCK(refd, b);
-        kept++;
-      } else {
-        unrefd = BLOCK(unrefd, b);
-      }
-    }
-    if (kept == last_kept)
-      break;
-    last_kept = kept;
-    binder = unrefd;
-    unrefd = gen_noop();
+
+  if (block_bind_subblock(binder, body, bindflags, 0) == 0) {
+    block_free(binder);
+  } else {
+    body = BLOCK(binder, body);
   }
-  block_free(unrefd);
-  return block_join(refd, body);
+  return body;
 }
 
 static void block_mark_referenced(block body) {

--- a/src/linker.c
+++ b/src/linker.c
@@ -98,12 +98,9 @@ static jv validate_relpath(jv name) {
     return res;
   }
   jv components = jv_string_split(jv_copy(name), jv_string("/"));
-  jv rp = jv_array_get(jv_copy(components), 0);
-  components = jv_array_slice(components, 1, jv_array_length(jv_copy(components)));
   jv_array_foreach(components, i, x) {
     if (!strcmp(jv_string_value(x), "..")) {
       jv_free(x);
-      jv_free(rp);
       jv_free(components);
       jv res = jv_invalid_with_msg(jv_string_fmt("Relative paths to modules may not traverse to parent directories (%s)", s));
       jv_free(name);
@@ -111,18 +108,16 @@ static jv validate_relpath(jv name) {
     }
     if (i > 0 && jv_equal(jv_copy(x), jv_array_get(jv_copy(components), i - 1))) {
       jv_free(x);
-      jv_free(rp);
       jv_free(components);
       jv res = jv_invalid_with_msg(jv_string_fmt("module names must not have equal consecutive components: %s",
                                                  jv_string_value(name)));
       jv_free(name);
       return res;
     }
-    rp = jv_string_concat(rp, jv_string_concat(jv_string("/"), x));
+    jv_free(x);
   }
   jv_free(components);
-  jv_free(name);
-  return rp;
+  return name;
 }
 
 // Assumes name has been validated

--- a/src/linker.c
+++ b/src/linker.c
@@ -387,6 +387,16 @@ int load_program(jq_state *jq, struct locfile* src, block *out_block) {
   if (nerrors)
     return nerrors;
 
+  char* home = getenv("HOME");
+  if (home) {    // silently ignore no $HOME
+    /* Import ~/.jq as a library named "" found in $HOME */
+    block import = gen_import_meta(gen_import("", NULL, 0),
+        gen_const(JV_OBJECT(
+            jv_string("optional"), jv_true(),
+            jv_string("search"), jv_string(home))));
+    program = BLOCK(import, program);
+  }
+
   nerrors = process_dependencies(jq, jq_get_jq_origin(jq), jq_get_prog_origin(jq), &program, &lib_state);
   block libs = gen_noop();
   for (uint64_t i = 0; i < lib_state.ct; ++i) {

--- a/src/linker.c
+++ b/src/linker.c
@@ -138,10 +138,20 @@ static jv jv_basename(jv name) {
 
 // Asummes validated relative path to module
 static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv jq_origin, jv lib_origin) {
-  if (jv_get_kind(search) != JV_KIND_ARRAY)
-    return jv_invalid_with_msg(jv_string_fmt("Module search path must be an array"));
-  if (jv_get_kind(rel_path) != JV_KIND_STRING)
+  if (!jv_is_valid(rel_path)) {
+    jv_free(search);
+    return rel_path;
+  }
+  if (jv_get_kind(rel_path) != JV_KIND_STRING) {
+    jv_free(rel_path);
+    jv_free(search);
     return jv_invalid_with_msg(jv_string_fmt("Module path must be a string"));
+  }
+  if (jv_get_kind(search) != JV_KIND_ARRAY) {
+    jv_free(rel_path);
+    jv_free(search);
+    return jv_invalid_with_msg(jv_string_fmt("Module search path must be an array"));
+  }
 
   struct stat st;
   int ret;


### PR DESCRIPTION
There are no performance improvements in this patchset, unfortunately.

It's just an attempt at cleaning up `builtins_bind` to make a better springboard for working out the details of #1826 without having ~/.jq guts in the same function, when it can better be loaded as a library that just happens to have the same name and location.

There is a small incompatibility in the resolution order of shadowed names, but that's already buggy IMO (#1828) so I don't think it matters.

(https://github.com/muhmuhten/jq/commit/070299079ae68c8c56f50eabf42d7c1b4aae21da is a slightly more truthful history of this changeset.)