### PR TITLE
Binding only referenced builtins

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1743,7 +1743,7 @@ static block bind_bytecoded_builtins(block b) {
                                             BLOCK(gen_param("start"), gen_param("end")),
                                             range));
   }
-  return block_bind(builtins, b, OP_IS_CALL_PSEUDO);
+  return BLOCK(builtins, b);
 }
 
 static const char jq_builtins[] =
@@ -1793,7 +1793,7 @@ int builtins_bind(jq_state *jq, block* bb) {
   builtins = gen_cbinding(function_list, sizeof(function_list)/sizeof(function_list[0]), builtins);
   builtins = gen_builtin_list(builtins);
 
-  *bb = block_bind(builtins, *bb, OP_IS_CALL_PSEUDO);
+  *bb = block_bind_incremental(builtins, *bb, OP_IS_CALL_PSEUDO);
   *bb = block_drop_unreferenced(*bb);
   return nerrors;
 }

--- a/src/compile.h
+++ b/src/compile.h
@@ -72,9 +72,10 @@ int block_has_only_binders(block, int bindflags);
 int block_has_main(block);
 int block_is_funcdef(block b);
 int block_is_single(block b);
-block block_bind(block binder, block body, int bindflags);
 block block_bind_library(block binder, block body, int bindflags, const char* libname);
 block block_bind_referenced(block binder, block body, int bindflags);
+block block_bind_incremental(block binder, block body, int bindflags);
+block block_bind_self(block binder, int bindflags);
 block block_drop_unreferenced(block body);
 
 jv block_take_imports(block* body);

--- a/src/linker.c
+++ b/src/linker.c
@@ -336,6 +336,7 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, const c
                                       jv_string(dirname(lib_origin)),
                                       &program, lib_state);
       free(lib_origin);
+      program = block_bind_self(program, OP_IS_CALL_PSEUDO);
     }
   }
   state_idx = lib_state->ct++;

--- a/src/parser.c
+++ b/src/parser.c
@@ -2423,7 +2423,7 @@ yyreduce:
   case 9:
 #line 333 "src/parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = block_bind((yyvsp[-1].blk), (yyvsp[0].blk), OP_IS_CALL_PSEUDO);
+  (yyval.blk) = block_join((yyvsp[-1].blk), (yyvsp[0].blk));
 }
 #line 2429 "src/parser.c" /* yacc.c:1646  */
     break;

--- a/src/parser.y
+++ b/src/parser.y
@@ -331,7 +331,7 @@ FuncDefs:
   $$ = gen_noop();
 } |
 FuncDef FuncDefs {
-  $$ = block_bind($1, $2, OP_IS_CALL_PSEUDO);
+  $$ = block_join($1, $2);
 }
 
 Exp:


### PR DESCRIPTION
aka "make startup time as fast as (probably a bit faster than) 1.5"
aka "omg omg I think I actually managed to pull it off in a kind of elegant way and it's like 3x faster now"

By having the parser spit out libraries without bindings, we can get a list of builtins and bind them backwards onto the main program, dropping the unreferenced ones:

- without "two newlines"-style contortions―we can get the information directly from the parse tree
- we can keep `builtins/0`, since we can read off symbols before we drop unreferenced defs
- **we don't need to search unreferenced blocks for symbols**

Now, in theory this should also be possible for libraries, but `block_bind_library` is kind of black magic and the caching looks like it would play poorly with the "blocks coming out of the parser *aren't* bound to each other" assumption (which gives us the property that a binder is referenced *iff it binds something* that gets counted in `block_bind_subblock_inner`).
So for now we just link libraries to themselves as soon as possible and do the same thing we used to. I don't think this is as big a problem as the builtins anyway.

Builds on top of and supersedes #1830, which lays the groundwork by redefining block_bind_referenced to a form simple enough to understand in context here, and ripping out ~/.jq's special-casing which would've been nasty to add support for in `builtins_bind`.