### PR TITLE
Ensure limit(0; ...) is empty

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -168,9 +168,9 @@ def until(cond; next):
          if cond then . else (next|_until) end;
      _until;
 def limit($n; exp):
-  if $n < 0 then exp
-  else label $out | foreach exp as $item ($n; .-1; $item, if . <= 0 then break $out else empty end)
-  end;
+    if $n > 0 then label $out | foreach exp as $item ($n; .-1; $item, if . <= 0 then break $out else empty end)
+    elif $n == 0 then empty
+    else exp end;
 def isempty(g): 0 == ((label $go | g | (1, break $go)) // 0);
 def first(g): label $out | g | ., break $out;
 def last(g): reduce g as $item (null; $item);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -304,6 +304,14 @@ null
 [11,22,33,44,55,66,77,88,99]
 [11,22,33]
 
+[limit(0; error)]
+"badness"
+[]
+
+[limit(1; 1, error)]
+"badness"
+[1]
+
 [first(range(.)), last(range(.)), nth(0; range(.)), nth(5; range(.)), try nth(-1; range(.)) catch .]
 10
 [0,9,0,5,"nth doesn't support negative indices"]


### PR DESCRIPTION
> 00:29 &lt;chancez> can someone tell me why `jq -n '. | limit(0; [1,2,3] | .[])'` outputs 1?
> 00:29 &lt;chancez> shouldn't limit(0; input) always return an empty result?
> 05:04 &lt;tristero> chancez: that produces an empty result here, jq 1.5.1
> 07:33 &lt;geirha> # jq -cn 'limit(2; (1,2,3))'
> 07:33 &lt;shbot> geirha: 1
> 07:33 &lt;shbot> geirha: 2
> 07:33 &lt;geirha> # jq -cn 'limit(0; (1,2,3))'
> 07:33 &lt;shbot> geirha: 1
> 07:33 &lt;geirha> looks like a bug in 1.6 then
> 07:44 &lt;wtlangford> geirha: Looks like that behavior was introduced in 7fd9e86e.
> 07:49 &lt;wtlangford> geirha: I'm not certain it's a bug. Something about it makes me think there was an intention to the change. That said, you can do something like this to work
> 07:50 &lt;geirha> chancez: ^
> 08:41 &lt;ammunta> I don't think it's intentional, it just requires explicit checking for 0
> 08:42 &lt;ammunta> the obvious fix (swapping the item and the conditional break) evaluates one more item than needed
> 08:48 &lt;ammunta> ah, I thought it sounded familiar
> 08:50 &lt;ammunta> https://github.com/stedolan/jq/issues/1616 yeah I don't think limit(0; exp) taking the first element is intentional there
