### PR TITLE
Enhanced `any` and `all`.

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -32,20 +32,13 @@ def index($i):   indices($i) | .[0];       # TODO: optimize
 def rindex($i):  indices($i) | .[-1:][0];  # TODO: optimize
 def paths: path(recurse(if (type|. == "array" or . == "object") then .[] else empty end))|select(length > 0);
 def paths(node_filter): . as $dot|paths|select(. as $p|$dot|getpath($p)|node_filter);
-def any(generator; condition):
-        [label $out | foreach generator as $i
-                 (false;
-                  if . then break $out elif $i | condition then true else . end;
-                  if . then . else empty end)] | length == 1;
-def any(condition): any(.[]; condition);
-def any: any(.);
-def all(generator; condition):
-        [label $out | foreach generator as $i
-                 (true;
-                  if .|not then break $out elif $i | condition then . else false end;
-                  if .|not then . else empty end)] | length == 0;
-def all(condition): all(.[]; condition);
-def all: all(.);
+def isempty(g): 0 == ((label $go | g | (1, break $go)) // 0);
+def any(generator; condition): false==isempty(generator | condition or empty);
+def any: false==isempty(.[] or empty);
+def any(condition): false==isempty(.[] | condition or empty);
+def all(generator; condition): isempty(generator | condition and empty);
+def all: isempty(.[] and empty);
+def all(condition): isempty(.[] | condition and empty);
 def isfinite: type == "number" and (isinfinite | not);
 def arrays: select(type == "array");
 def objects: select(type == "object");
@@ -171,7 +164,6 @@ def limit($n; exp):
     if $n > 0 then label $out | foreach exp as $item ($n; .-1; $item, if . <= 0 then break $out else empty end)
     elif $n == 0 then empty
     else exp end;
-def isempty(g): 0 == ((label $go | g | (1, break $go)) // 0);
 def first(g): label $out | g | ., break $out;
 def last(g): reduce g as $item (null; $item);
 def nth($n; g): if $n < 0 then error("nth doesn't support negative indices") else last(limit($n + 1; g)) end;


### PR DESCRIPTION
After the last changes in `builtin.jq` my old pull requests cannot merge automatically. I hope
my enhanced definitions for `any` and `all` in this new pull request can be merged soon. The new definitions are:

- faster
- a lot more _jq_ idiomatic
- a lot shorter
- a god example of programming with `empty`

JJOR