### PR TITLE
Add tests for {any,all}/{0,1}

### DIFF
--- a/tests/jq.test
+++ b/tests/jq.test
@@ -851,6 +851,51 @@ false
 [1,2,3,4,true]
 true
 
+# Check short-circuiting
+any(true, error; .)
+"badness"
+true
+
+all(false, error; .)
+"badness"
+false
+
+any(not)
+[]
+false
+
+all(not)
+[]
+true
+
+any(not)
+[false]
+true
+
+all(not)
+[false]
+true
+
+[any,all]
+[]
+[false,true]
+
+[any,all]
+[true]
+[true,true]
+
+[any,all]
+[false]
+[false,false]
+
+[any,all]
+[true,false]
+[true,false]
+
+[any,all]
+[null,null,true]
+[true,false]
+
 #
 # Paths
 #


### PR DESCRIPTION
Prompted by an embarrassing mistake I made earlier while trying to find nicer definitions (https://github.com/stedolan/jq/pull/1839#issuecomment-466679993).

The short-circuit tests are failing! This shows that they are needed :-)