### PR TITLE
Remove block_drop_unreferenced after binding builtins

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1794,6 +1794,5 @@ int builtins_bind(jq_state *jq, block* bb) {
   builtins = gen_builtin_list(builtins);
 
   *bb = block_bind_referenced(builtins, *bb, OP_IS_CALL_PSEUDO);
-  *bb = block_drop_unreferenced(*bb);
   return nerrors;
 }

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1793,7 +1793,7 @@ int builtins_bind(jq_state *jq, block* bb) {
   builtins = gen_cbinding(function_list, sizeof(function_list)/sizeof(function_list[0]), builtins);
   builtins = gen_builtin_list(builtins);
 
-  *bb = block_bind_incremental(builtins, *bb, OP_IS_CALL_PSEUDO);
+  *bb = block_bind_referenced(builtins, *bb, OP_IS_CALL_PSEUDO);
   *bb = block_drop_unreferenced(*bb);
   return nerrors;
 }

--- a/src/compile.c
+++ b/src/compile.c
@@ -503,7 +503,7 @@ block block_drop_unreferenced(block body) {
     if (curr->bound_by == curr && !curr->referenced) {
       inst_free(curr);
     } else {
-      refd = BLOCK(inst_block(curr), refd);
+      refd = BLOCK(refd, inst_block(curr));
     }
   }
   return refd;

--- a/src/compile.h
+++ b/src/compile.h
@@ -74,7 +74,6 @@ int block_is_funcdef(block b);
 int block_is_single(block b);
 block block_bind_library(block binder, block body, int bindflags, const char* libname);
 block block_bind_referenced(block binder, block body, int bindflags);
-block block_bind_incremental(block binder, block body, int bindflags);
 block block_bind_self(block binder, int bindflags);
 block block_drop_unreferenced(block body);
 


### PR DESCRIPTION
Since the new builtin binding procedure implicitly drops unreferenced builtins, dropping unreferenced blocks *again* after should never do anything useful.

(It happens that it undid a block-flipping bug, though.)

Combines block_bind_referenced and block_bind_incremental in the process since they do the same thing and the latter is kind of a nonsense name.