### PR TITLE
Restore cfunction arity in builtins/0

### DIFF
--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1646,4 +1646,19 @@ index("")
 ""
 null
 
+# check that dead code removal occurs after builtin it generation
+builtins|length > 10
+null
+true
 
+"-1"|IN(builtins[] / "/"|.[1])
+null
+false
+
+all(builtins[] / "/"; .[1]|tonumber >= 0)
+null
+true
+
+builtins|any(.[:1] == "_")
+null
+false


### PR DESCRIPTION
Count arguments up-front at definition/invocation instead of doing it at
bind time, which comes after generating builtins/0 since e843a4f.

(mea culpa)

(and also add some tests for builtins/0)