### PR TITLE
Add const modifiers to pointer function arguments that don't get modified

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -232,7 +232,7 @@ static jv f_endswith(jq_state *jq, jv a, jv b) {
   const char *bstr = jv_string_value(b);
   size_t alen = jv_string_length_bytes(jv_copy(a));
   size_t blen = jv_string_length_bytes(jv_copy(b));
-  jv ret;;
+  jv ret;
 
   if (alen < blen ||
      memcmp(astr + (alen - blen), bstr, blen) != 0)

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -37,7 +37,7 @@ const struct opcode_description* opcode_describe(opcode op) {
 }
 
 
-int bytecode_operation_length(uint16_t* codeptr) {
+int bytecode_operation_length(const uint16_t* codeptr) {
   int length = opcode_describe(*codeptr)->length;
   if (*codeptr == CALL_JQ || *codeptr == TAIL_CALL_JQ) {
     length += codeptr[1] * 2;
@@ -92,7 +92,7 @@ static struct bytecode* getlevel(struct bytecode* bc, int level) {
   return bc;
 }
 
-void dump_operation(struct bytecode* bc, uint16_t* codeptr) {
+void dump_operation(struct bytecode* bc, const uint16_t* codeptr) {
   int pc = codeptr - bc->code;
   printf("%04d ", pc);
   const struct opcode_description* op = opcode_describe(bc->code[pc++]);

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -84,9 +84,9 @@ struct bytecode {
 };
 
 void dump_disassembly(int, struct bytecode* code);
-void dump_operation(struct bytecode* bc, uint16_t* op);
+void dump_operation(struct bytecode* bc, const uint16_t* op);
 
-int bytecode_operation_length(uint16_t* codeptr);
+int bytecode_operation_length(const uint16_t* codeptr);
 void bytecode_free(struct bytecode* bc);
 
 #endif

--- a/src/compile.c
+++ b/src/compile.c
@@ -275,10 +275,6 @@ int block_has_only_binders_and_imports(block binders, int bindflags) {
   return 1;
 }
 
-static int inst_is_binder(inst *i, int bindflags) {
-  return !((opcode_describe(i->op)->flags & bindflags) != bindflags && i->op != MODULEMETA);
-}
-
 int block_has_only_binders(block binders, int bindflags) {
   bindflags |= OP_HAS_BINDING;
   bindflags &= ~OP_BIND_WILDCARD;

--- a/src/compile.c
+++ b/src/compile.c
@@ -1099,7 +1099,7 @@ block gen_cbinding(const struct cfunction* cfunctions, int ncfunctions, block co
   return code;
 }
 
-static uint16_t nesting_level(struct bytecode* bc, inst* target) {
+static uint16_t nesting_level(const struct bytecode* bc, const inst* target) {
   uint16_t level = 0;
   assert(bc && target && target->compiled);
   while (bc && target->compiled != bc) {
@@ -1233,7 +1233,7 @@ static int expand_call_arglist(block* b, jv args, jv *env) {
   return errors;
 }
 
-static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv *env) {
+static int compile(struct bytecode* bc, block b, const struct locfile* lf, jv args, jv *env) {
   int errors = 0;
   int pos = 0;
   int var_frame_idx = 0;
@@ -1366,7 +1366,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
   return errors;
 }
 
-int block_compile(block b, struct bytecode** out, struct locfile* lf, jv args) {
+int block_compile(block b, struct bytecode** out, const struct locfile* lf, jv args) {
   struct bytecode* bc = jv_mem_alloc(sizeof(struct bytecode));
   bc->parent = 0;
   bc->nclosures = 0;

--- a/src/compile.c
+++ b/src/compile.c
@@ -289,7 +289,7 @@ int block_has_only_binders(block binders, int bindflags) {
 // Count a call site's actual params
 static int block_count_actuals(block b) {
   int args = 0;
-  for (inst* i = b.first; i; i = i->next) {
+  for (const inst* i = b.first; i; i = i->next) {
     switch (i->op) {
     default: assert(0 && "Unknown function type"); break;
     case CLOSURE_CREATE:
@@ -499,7 +499,7 @@ jv block_take_imports(block* body) {
 
 jv block_list_funcs(block body, int omit_underscores) {
   jv funcs = jv_object(); // Use the keys for set semantics.
-  for (inst *pos = body.first; pos != NULL; pos = pos->next) {
+  for (const inst *pos = body.first; pos != NULL; pos = pos->next) {
     if (pos->op == CLOSURE_CREATE || pos->op == CLOSURE_CREATE_C) {
       if (pos->symbol != NULL && (!omit_underscores || pos->symbol[0] != '_')) {
         funcs = jv_object_set(funcs, jv_string_fmt("%s/%i", pos->symbol, pos->nformals), jv_null());
@@ -690,7 +690,7 @@ static block gen_const_array(block expr) {
   int commas = 0;
   int normal = 1;
   jv a = jv_array();
-  for (inst *i = expr.first; i; i = i->next) {
+  for (const inst *i = expr.first; i; i = i->next) {
     if (i->op == FORK) {
       commas++;
       if (i->imm.target == NULL || i->imm.target->op != JUMP ||
@@ -918,7 +918,7 @@ block gen_definedor(block a, block b) {
 }
 
 int block_has_main(block top) {
-  for (inst *c = top.first; c; c = c->next) {
+  for (const inst *c = top.first; c; c = c->next) {
     if (c->op == TOP)
       return 1;
   }
@@ -1112,7 +1112,7 @@ static uint16_t nesting_level(struct bytecode* bc, inst* target) {
 
 static int count_cfunctions(block b) {
   int n = 0;
-  for (inst* i = b.first; i; i = i->next) {
+  for (const inst* i = b.first; i; i = i->next) {
     if (i->op == CLOSURE_CREATE_C) n++;
     n += count_cfunctions(i->subfn);
   }

--- a/src/compile.h
+++ b/src/compile.h
@@ -80,7 +80,7 @@ block block_drop_unreferenced(block body);
 jv block_take_imports(block* body);
 jv block_list_funcs(block body, int omit_underscores);
 
-int block_compile(block, struct bytecode**, struct locfile*, jv);
+int block_compile(block, struct bytecode**, const struct locfile*, jv);
 
 void block_free(block);
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -105,7 +105,7 @@ static jv* frame_local_var(struct jq_state* jq, int var, int level) {
   return &fr->entries[fr->bc->nclosures + var].localvar;
 }
 
-static struct closure make_closure(struct jq_state* jq, uint16_t* pc) {
+static struct closure make_closure(struct jq_state* jq, const uint16_t* pc) {
   uint16_t level = *pc++;
   uint16_t idx = *pc++;
   stack_ptr fridx = frame_get_level(jq, level);
@@ -129,7 +129,7 @@ static struct closure make_closure(struct jq_state* jq, uint16_t* pc) {
 }
 
 static struct frame* frame_push(struct jq_state* jq, struct closure callee,
-                                uint16_t* argdef, int nargs) {
+                                const uint16_t* argdef, int nargs) {
   stack_ptr new_frame_idx = stack_push_block(&jq->stk, jq->curr_frame, frame_size(callee.bc));
   struct frame* new_frame = stack_block(&jq->stk, new_frame_idx);
   new_frame->bc = callee.bc;
@@ -204,7 +204,7 @@ struct stack_pos {
   stack_ptr saved_data_stack, saved_curr_frame;
 };
 
-struct stack_pos stack_get_pos(jq_state* jq) {
+struct stack_pos stack_get_pos(const jq_state* jq) {
   struct stack_pos sp = {jq->stk_top, jq->curr_frame};
   return sp;
 }
@@ -1064,7 +1064,7 @@ void jq_teardown(jq_state **jq) {
   jv_mem_free(old_jq);
 }
 
-static int ret_follows(uint16_t *pc) {
+static int ret_follows(const uint16_t *pc) {
   if (*pc == RET)
     return 1;
   if (*pc++ != JUMP)
@@ -1096,7 +1096,7 @@ static int ret_follows(uint16_t *pc) {
  *
  * b) none of the closures -callee included- have level == 0.
  */
-static uint16_t tail_call_analyze(uint16_t *pc) {
+static uint16_t tail_call_analyze(const uint16_t *pc) {
   assert(*pc == CALL_JQ);
   pc++;
   // + 1 for the callee closure

--- a/src/execute.c
+++ b/src/execute.c
@@ -1242,7 +1242,7 @@ jq_halt(jq_state *jq, jv exit_code, jv error_message)
 }
 
 int
-jq_halted(jq_state *jq)
+jq_halted(const jq_state *jq)
 {
   return jq->halted;
 }

--- a/src/jq.h
+++ b/src/jq.h
@@ -59,7 +59,7 @@ jq_util_input_state *jq_util_input_init(jq_util_msg_cb, void *);
 void jq_util_input_set_parser(jq_util_input_state *, jv_parser *, int);
 void jq_util_input_free(jq_util_input_state **);
 void jq_util_input_add_input(jq_util_input_state *, const char *);
-int jq_util_input_errors(jq_util_input_state *);
+int jq_util_input_errors(const jq_util_input_state *);
 jv jq_util_input_next_input(jq_util_input_state *);
 jv jq_util_input_next_input_cb(jq_state *, void *);
 jv jq_util_input_get_position(jq_state*);

--- a/src/jq.h
+++ b/src/jq.h
@@ -27,7 +27,7 @@ jv jq_next(jq_state *);
 void jq_teardown(jq_state **);
 
 void jq_halt(jq_state *, jv, jv);
-int jq_halted(jq_state *);
+int jq_halted(const jq_state *);
 jv jq_get_exit_code(jq_state *);
 jv jq_get_error_message(jq_state *);
 

--- a/src/jv.c
+++ b/src/jv.c
@@ -32,7 +32,7 @@ static int jvp_refcnt_dec(jv_refcnt* c) {
   return c->count == 0;
 }
 
-static int jvp_refcnt_unshared(jv_refcnt* c) {
+static int jvp_refcnt_unshared(const jv_refcnt* c) {
   assert(c->count > 0);
   return c->count == 1;
 }

--- a/src/jv.c
+++ b/src/jv.c
@@ -504,11 +504,11 @@ static void jvp_string_free(jv js) {
   }
 }
 
-static uint32_t jvp_string_length(jvp_string* s) {
+static uint32_t jvp_string_length(const jvp_string* s) {
   return s->length_hashed >> 1;
 }
 
-static uint32_t jvp_string_remaining_space(jvp_string* s) {
+static uint32_t jvp_string_remaining_space(const jvp_string* s) {
   assert(s->alloc_length >= jvp_string_length(s));
   uint32_t r = s->alloc_length - jvp_string_length(s);
   return r;

--- a/src/jv.h
+++ b/src/jv.h
@@ -233,7 +233,7 @@ jv jv_load_file(const char *, int);
 typedef struct jv_parser jv_parser;
 jv_parser* jv_parser_new(int);
 void jv_parser_set_buf(jv_parser*, const char*, int, int);
-int jv_parser_remaining(jv_parser*);
+int jv_parser_remaining(const jv_parser*);
 jv jv_parser_next(jv_parser*);
 void jv_parser_free(jv_parser*);
 

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -397,7 +397,7 @@ static void tokenadd(struct jv_parser* p, char c) {
   p->tokenbuf[p->tokenpos++] = c;
 }
 
-static int unhex4(char* hex) {
+static int unhex4(const char* hex) {
   int r = 0;
   for (int i=0; i<4; i++) {
     char c = *hex++;
@@ -566,20 +566,20 @@ static int stream_check_done(struct jv_parser* p, jv* out) {
   }
 }
 
-static int parse_check_truncation(struct jv_parser* p) {
+static int parse_check_truncation(const struct jv_parser* p) {
   return ((p->flags & JV_PARSE_SEQ) && !p->last_ch_was_ws && (p->stackpos > 0 || p->tokenpos > 0 || jv_get_kind(p->next) == JV_KIND_NUMBER));
 }
 
-static int stream_check_truncation(struct jv_parser* p) {
+static int stream_check_truncation(const struct jv_parser* p) {
   jv_kind k = jv_get_kind(p->next);
   return (p->stacklen > 0 || k == JV_KIND_NUMBER || k == JV_KIND_TRUE || k == JV_KIND_FALSE || k == JV_KIND_NULL);
 }
 
-static int parse_is_top_num(struct jv_parser* p) {
+static int parse_is_top_num(const struct jv_parser* p) {
   return (p->stackpos == 0 && jv_get_kind(p->next) == JV_KIND_NUMBER);
 }
 
-static int stream_is_top_num(struct jv_parser* p) {
+static int stream_is_top_num(const struct jv_parser* p) {
   return (p->stacklen == 0 && jv_get_kind(p->next) == JV_KIND_NUMBER);
 }
 
@@ -674,7 +674,7 @@ void jv_parser_free(struct jv_parser* p) {
 
 static const unsigned char UTF8_BOM[] = {0xEF,0xBB,0xBF};
 
-int jv_parser_remaining(struct jv_parser* p) {
+int jv_parser_remaining(const struct jv_parser* p) {
   if (p->curr_buf == 0)
     return 0;
   return (p->curr_buf_length - p->curr_buf_pos);
@@ -705,9 +705,9 @@ void jv_parser_set_buf(struct jv_parser* p, const char* buf, int length, int is_
   p->curr_buf_is_partial = is_partial;
 }
 
-static jv make_error(struct jv_parser*, const char *, ...) JV_PRINTF_LIKE(2, 3);
+static jv make_error(const struct jv_parser*, const char *, ...) JV_PRINTF_LIKE(2, 3);
 
-static jv make_error(struct jv_parser* p, const char *fmt, ...) {
+static jv make_error(const struct jv_parser* p, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   jv e = jv_string_vfmt(fmt, ap);

--- a/src/locfile.c
+++ b/src/locfile.c
@@ -47,7 +47,7 @@ void locfile_free(struct locfile* l) {
   }
 }
 
-int locfile_get_line(struct locfile* l, int pos) {
+int locfile_get_line(const struct locfile* l, int pos) {
   assert(pos < l->length);
   int line = 1;
   while (l->linemap[line] <= pos) line++;   // == if pos at start (before, never ==, because pos never on \n)
@@ -55,12 +55,12 @@ int locfile_get_line(struct locfile* l, int pos) {
   return line-1;
 }
 
-static int locfile_line_length(struct locfile* l, int line) {
+static int locfile_line_length(const struct locfile* l, int line) {
   assert(line < l->nlines);
   return l->linemap[line+1] - l->linemap[line] -1;   // -1 to omit \n
 }
 
-void locfile_locate(struct locfile* l, location loc, const char* fmt, ...) {
+void locfile_locate(const struct locfile* l, location loc, const char* fmt, ...) {
   va_list fmtargs;
   va_start(fmtargs, fmt);
   int startline;

--- a/src/locfile.h
+++ b/src/locfile.h
@@ -22,8 +22,8 @@ struct locfile {
 
 struct locfile* locfile_init(jq_state *, const char *, const char *, int);
 struct locfile* locfile_retain(struct locfile *);
-int locfile_get_line(struct locfile *, int);
+int locfile_get_line(const struct locfile *, int);
 void locfile_free(struct locfile *);
-void locfile_locate(struct locfile *, location, const char *, ...);
+void locfile_locate(const struct locfile *, location, const char *, ...);
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -259,7 +259,7 @@ void jq_util_input_add_input(jq_util_input_state *state, const char *fname) {
   state->files[state->nfiles++] = jv_mem_strdup(fname);
 }
 
-int jq_util_input_errors(jq_util_input_state *state) {
+int jq_util_input_errors(const jq_util_input_state *state) {
   return state->failures;
 }
 


### PR DESCRIPTION
jq uses `const` pointers all over, but there are a few instances that I found where `const` can get added to function arguments.  This helps show intent of the function, and helps the compiler keep track of when variables are getting modified.

I hope this helps with jq's maintainability.  Thanks for a great tool.

(Aside: I was inspired to look into the internals of jq because I just wrote an article where I suggested people use it: https://blog.newrelic.com/engineering/7-things-never-code/)