### PR TITLE
Add pkg-config file for libjq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ jq.1
 
 # Generated source
 src/builtin.inc
+*.pc
 
 # Autotools junk
 .libs

--- a/Makefile.am
+++ b/Makefile.am
@@ -175,6 +175,7 @@ DOC_FILES = docs/content docs/public docs/templates docs/site.yml       \
 EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         jq.1.prebuilt jq.spec src/lexer.c src/lexer.h src/parser.c      \
         src/parser.h src/version.h src/builtin.jq scripts/version       \
+        libjq.pc                                                        \
         tests/base64.test tests/jq-f-test.sh tests/jq.test              \
         tests/modules/a.jq tests/modules/b/b.jq tests/modules/c/c.jq    \
         tests/modules/c/d.jq tests/modules/data.json                    \
@@ -193,6 +194,9 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
 # distribute it and install it with the package in the doc directory.
 docdir = ${datadir}/doc/${PACKAGE}
 dist_doc_DATA = README.md COPYING AUTHORS README
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libjq.pc
 
 RELEASE ?= 1
 rpm: dist jq.spec

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,6 @@ AM_CONDITIONAL([BUILD_ONIGURUMA], [test "x$build_oniguruma" = xyes])
 AC_SUBST([BUNDLER], ["$bundle_cmd"])
 
 AC_CONFIG_MACRO_DIR([config/m4])
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile libjq.pc])
 AC_OUTPUT
 

--- a/libjq.pc.in
+++ b/libjq.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libjq
+URL: https://stedolan.github.io/jq/
+Description: Library to process JSON using a query language
+Version: @VERSION@
+Libs: -L${libdir} -ljq
+Cflags: -I${includedir}


### PR DESCRIPTION
pkg-config is a common interface to resolve build details. It will
become easier to incorporate libjq in other projects by providing this
interface.