### PR TITLE
jq_util_input_init: Zero memory using calloc

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -208,20 +208,11 @@ jq_util_input_state *jq_util_input_init(jq_util_msg_cb err_cb, void *err_cb_data
     err_cb = fprinter;
     err_cb_data = stderr;
   }
-  jq_util_input_state *new_state = jv_mem_alloc(sizeof(*new_state));
-  memset(new_state, 0, sizeof(*new_state));
+  jq_util_input_state *new_state = jv_mem_calloc(1, sizeof(*new_state));
   new_state->err_cb = err_cb;
   new_state->err_cb_data = err_cb_data;
-  new_state->parser = NULL;
-  new_state->current_input = NULL;
-  new_state->files = NULL;
-  new_state->nfiles = 0;
-  new_state->curr_file = 0;
   new_state->slurped = jv_invalid();
-  new_state->buf[0] = 0;
-  new_state->buf_valid_len = 0;
   new_state->current_filename = jv_invalid();
-  new_state->current_line = 0;
 
   return new_state;
 }


### PR DESCRIPTION
Calloc will zero the allocated memory which makes one memset and a
number of explicit zero assignments redundant.