### PR TITLE
clarify filter usage

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -317,8 +317,9 @@ sections:
           is, keys that are all made of alphanumeric characters and
           underscore, and which do not start with a digit.
 
-          If the key contains special characters, you need to surround
-          it with double quotes like this: `."foo$"`, or else `.["foo$"]`.
+          If the key contains special characters or starts with a digit,
+          you need to surround it with double quotes like this:
+          `."foo$"`, or else `.["foo$"]`.
 
           For example `.["foo::bar"]` and `.["foo.bar"]` work while
           `.foo::bar` does not, and `.foo.bar` means `.["foo"].["bar"]`.
@@ -2535,7 +2536,7 @@ sections:
 
       - title: 'Destructuring Alternative Operator: `?//`'
         body: |
-        
+
           The destructuring alternative operator provides a concise mechanism
           for destructuring an input that can take one of several forms.
 
@@ -2544,10 +2545,10 @@ sections:
           the first event for each resource. The API (having been clumsily
           converted from XML) will only wrap the events in an array if the resource
           has multiple events:
-          
+
               {"resources": [{"id": 1, "kind": "widget", "events": {"action": "create", "user_id": 1, "ts": 13}},
                              {"id": 2, "kind": "widget", "events": [{"action": "create", "user_id": 1, "ts": 14}, {"action": "destroy", "user_id": 1, "ts": 15}]}]}
-          
+
           We can use the destructuring alternative operator to handle this structural change simply:
 
               .resources[] as {$id, $kind, events: {$user_id, $ts}} ?// {$id, $kind, events: [{$user_id, $ts}]} | {$user_id, $kind, $id, $ts}

--- a/docs/content/manual/v1.4/manual.yml
+++ b/docs/content/manual/v1.4/manual.yml
@@ -212,8 +212,8 @@ sections:
           JSON object (aka dictionary or hash) as input, it produces
           the value at the key "foo", or null if there's none present.
 
-          If the key contains special characters, you need to surround
-          it with double quotes like this: `."foo$"`.
+          If the key contains special characters or starts with a digit,
+          you need to surround it with double quotes like this: `."foo$"`.
 
           A filter of the form `.foo.bar` is equivalent to `.foo|.bar`.
 

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -278,8 +278,8 @@ sections:
           JSON object (aka dictionary or hash) as input, it produces
           the value at the key "foo", or null if there's none present.
 
-          If the key contains special characters, you need to surround
-          it with double quotes like this: `."foo$"`.
+          If the key contains special characters or starts with a digit,
+          you need to surround it with double quotes like this: `."foo$"`.
 
           A filter of the form `.foo.bar` is equivalent to `.foo|.bar`.
 

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -310,8 +310,9 @@ sections:
           is, keys that are all made of alphanumeric characters and
           underscore, and which do not start with a digit.
 
-          If the key contains special characters, you need to surround
-          it with double quotes like this: `."foo$"`, or else `.["foo$"]`.
+          If the key contains special characters or starts with a digit,
+          you need to surround it with double quotes like this:
+          `."foo$"`, or else `.["foo$"]`.
 
           For example `.["foo::bar"]` and `.["foo.bar"]` work while
           `.foo::bar` does not, and `.foo.bar` means `.["foo"].["bar"]`.
@@ -2512,7 +2513,7 @@ sections:
 
       - title: 'Destructuring Alternative Operator: `?//`'
         body: |
-        
+
           The destructuring alternative operator provides a concise mechanism
           for destructuring an input that can take one of several forms.
 
@@ -2521,10 +2522,10 @@ sections:
           the first event for each resource. The API (having been clumsily
           converted from XML) will only wrap the events in an array if the resource
           has multiple events:
-          
+
               {"resources": [{"id": 1, "kind": "widget", "events": {"action": "create", "user_id": 1, "ts": 13}},
                              {"id": 2, "kind": "widget", "events": [{"action": "create", "user_id": 1, "ts": 14}, {"action": "destroy", "user_id": 1, "ts": 15}]}]}
-          
+
           We can use the destructuring alternative operator to handle this structural change simply:
 
               .resources[] as {$id, $kind, events: {$user_id, $ts}} ?// {$id, $kind, events: [{$user_id, $ts}]} | {$user_id, $kind, $id, $ts}


### PR DESCRIPTION
The current paragraph is not complete, since a digit is not a special character.

Changing it to:

    If the key contains special characters or starts with a digit,
    you need to surround it with double quotes like this:
    `."foo$"`, or else `.["foo$"]`.