### PR TITLE
docs: fix seriously dangerous download instructions for Arch Linux

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -29,7 +29,7 @@ body:
 
        * jq 1.5 is in the official
          [Arch](https://www.archlinux.org/packages/?sort=&q=jq&maintainer=&flagged=)
-         repository.  Install using `sudo pacman -Sy jq`.
+         repository.  Install using `sudo pacman -S jq`.
 
        * jq 1.6 binaries for
          [64-bit](https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64)


### PR DESCRIPTION
The current instructions tell users to perform two actions:
- update the package database
- install the jq package

The only thing users need to or should be doing is actually installing the jq package -- regardless of which version is being installed. Guidelines on how to perform system updates are massively out of scope.

In the case of partially performing a system update as a prerequisite for installing jq, the official guidance from Arch Linux is not to do this: partial updates are not supported, we refuse to support them, and anyone who does try to perform them anyway is assumed to know so much about their system that they clearly do not ever need help from anyone else (which is a good thing since they won't get it). The result is a frankensteined system that can only ever be supported by the person who frankensteined it to begin with. The only reason the package manager even allows it to occur in the first place is because other distributions using pacman might have different LTS policies, and because it would prevent expert users from being in control of their system, as per the
traditional Unix philosophy:

"Unix was not designed to stop you from doing stupid things, because that would also stop you from doing clever things."

Consequences of performing partial updates without understanding the ramifications in extensive detail can include breaking the partially updated application (jq), breaking any application that shares a mutual dependency with the partially updated application (which jq is *lucky* to only depend on the ever-backwards-compatible glibc), or breaking the entire operating system by leaving armed traps behind for the next time a `pacman -S new-package` is executed and thereby breaks *its* cascading
dependencies.

See: https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported