### PR TITLE
Override field color with JQ_COLORS

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3284,9 +3284,10 @@ sections:
         - color for strings
         - color for arrays
         - color for objects
+        - color for field names
 
       The default color scheme is the same as setting
-      `"JQ_COLORS=1;30:0;39:0;39:0;39:0;32:1;39:1;39"`.
+      `"JQ_COLORS=1;30:0;39:0;39:0;39:0;32:1;39:1;39:1;34"`.
 
       This is not a manual for VT100/ANSI escapes.  However, each of
       these color specifications should consist of two numbers separated

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -30,9 +30,9 @@ static const jv_kind color_kinds[] =
 static char color_bufs[sizeof(color_kinds)/sizeof(color_kinds[0])][16];
 static const char *color_bufps[8];
 static const char* def_colors[] =
-  {COL("1;30"),    COL("0;39"),      COL("0;39"),     COL("0;39"),
-   COL("0;32"),      COL("1;39"),     COL("1;39")};
-#define FIELD_COLOR COL("34;1")
+  {COL("1;30"), COL("0;39"), COL("0;39"), COL("0;39"),
+   COL("0;32"), COL("1;39"), COL("1;39"), COL("1;34")};
+#define FIELD_COLOR_INDEX 7
 
 static const char **colors = def_colors;
 
@@ -328,7 +328,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
       if (color) put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);
 
       first = 0;
-      if (color) put_str(FIELD_COLOR, F, S, flags & JV_PRINT_ISATTY);
+      if (color) put_str(colors[FIELD_COLOR_INDEX], F, S, flags & JV_PRINT_ISATTY);
       jvp_dump_string(key, flags & JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
       jv_free(key);
       if (color) put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);

--- a/tests/shtest
+++ b/tests/shtest
@@ -285,22 +285,45 @@ cmp $d/color $d/expect
 JQ_COLORS='4;31' $JQ -Ccn . > $d/color
 printf '\033[4;31mnull\033[0m\n' > $d/expect
 cmp $d/color $d/expect
-JQ_COLORS='1;30:0;31:0;32:0;33:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color
+JQ_COLORS= \
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color
+(
+printf '\033[1;39m[\033[1;39m{'
+printf '\033[0m\033[1;34m"a"\033['
+printf '0m\033[1;39m:\033[0m\033['
+printf '0;39mtrue\033[0m\033[1'
+printf ';39m,\033[0m\033[1;34m'
+printf '"b"\033[0m\033[1;39m:\033'
+printf '[0m\033[0;39mfalse\033'
+printf '[0m\033[1;39m\033[1;39'
+printf 'm}\033[0m\033[1;39m,\033['
+printf '0;39m123\033[0m\033[1;'
+printf '39m,\033[1;30mnull\033'
+printf '[0m\033[1;39m,\033[0;3'
+printf '2m"string"\033[0m\033['
+printf '1;39m\033[1;39m]\033[0'
+printf 'm\n'
+) > $d/expect
+
+cmp $d/color $d/expect
+JQ_COLORS='1;30:0;31:0;32:0;33:0;34:1;35:1;36:1;37' \
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color
 (
 printf '\033[1;35m[\033[1;36m{'
-printf '\033[0m\033[34;1m"a"\033['
+printf '\033[0m\033[1;37m"a"\033['
 printf '0m\033[1;36m:\033[0m\033['
 printf '0;32mtrue\033[0m\033[1'
-printf ';36m,\033[0m\033[34;1m'
+printf ';36m,\033[0m\033[1;37m'
 printf '"b"\033[0m\033[1;36m:\033'
 printf '[0m\033[0;31mfalse\033'
 printf '[0m\033[1;36m\033[1;36'
 printf 'm}\033[0m\033[1;35m,\033['
 printf '0;33m123\033[0m\033[1;'
 printf '35m,\033[1;30mnull\033'
-printf '[0m\033[1;35m\033[1;35'
-printf 'm]\033[0m\n'
+printf '[0m\033[1;35m,\033[0;3'
+printf '4m"string"\033[0m\033['
+printf '1;35m\033[1;35m]\033[0'
+printf 'm\n'
 ) > $d/expect
 cmp $d/color $d/expect
 
@@ -310,25 +333,25 @@ cmp $d/color $d/expect
 # on stderr.
 set -vx
 echo 'Failed to set $JQ_COLORS' > $d/expect_warning
-$JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/expect
+$JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/expect
 JQ_COLORS='garbage;30:*;31:,;3^:0;$%:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color 2>$d/warning
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color 2>$d/warning
 cmp $d/color $d/expect
 cmp $d/warning $d/expect_warning
 JQ_COLORS='1234567890123456789;30:0;31:0;32:0;33:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color 2>$d/warning
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color 2>$d/warning
 cmp $d/color $d/expect
 cmp $d/warning $d/expect_warning
 JQ_COLORS='1;31234567890123456789:0;31:0;32:0;33:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color 2>$d/warning
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color 2>$d/warning
 cmp $d/color $d/expect
 cmp $d/warning $d/expect_warning
 JQ_COLORS='1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456' \
-  $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color 2>$d/warning
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color 2>$d/warning
 cmp $d/color $d/expect
 cmp $d/warning $d/expect_warning
 JQ_COLORS="0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:" \
-  $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color 2>$d/warning
+  $JQ -Ccn '[{"a":true,"b":false},123,null,"string"]' > $d/color 2>$d/warning
 cmp $d/color $d/expect
 cmp $d/warning $d/expect_warning
 


### PR DESCRIPTION
This is a small enhancement to make the field color configurable via the existing JQ_COLORS environment variable by allowing the field color to be specified as the eighth color.  If JQ_COLORS contains only seven colors, then the field color will continue to default to bold blue (1;34).

Below is an example JQ_COLORS string that makes the field names bold yellow:

export JQ_COLORS='1;30:1;32:1;32:1;32:1;31:0;37:0;37:1;33'
