### PR TITLE
Updates for compile-ios.sh

### DIFF
--- a/compile-ios.sh
+++ b/compile-ios.sh
@@ -46,7 +46,7 @@ CC_="$(xcrun -f clang || echo clang)"
 
 onig_url="https://github.com/kkos/oniguruma/releases/download/v${oniguruma}/onig-${oniguruma}.tar.gz"
 builddir="${TMPDIR:-/tmp}/${RANDOM:-'xxxxx'}-compile-ios-build"
-cwd="$(realpath ${PWD})"
+cwd="$(realpath ${PWD} 2>/dev/null || echo ${PWD})"
 
 t_exit() {
 cat << EOF

--- a/compile-ios.sh
+++ b/compile-ios.sh
@@ -1,4 +1,4 @@
--#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Mac C. compile-ios.sh for JQ.
 
 # Defaults
@@ -19,7 +19,7 @@ ${0##*/}: usage
 
     Arguments:
     --extra-cflags <arg>: Pass defines or includes to clang.
-    --extra-ldflags <arg>: Pass libs or included to ld64.
+    --extra-ldflags <arg>: Pass libs or includes to ld64.
 
     --with-oniguruma <arg>: Change default version of onigurma from ${oniguruma}.
 EOF
@@ -52,7 +52,7 @@ t_exit() {
 cat << EOF
 
 A error as occured.
-    oniguruma location: ${builddir}/onig
+    oniguruma location: ${builddir}/onig/onig-${oniguruma}
     jq location: ${cwd}
 
     Provide config.log and console logs when posting a issue.
@@ -90,7 +90,7 @@ cd "${builddir}/"
      [[ ! -f ./configure ]] && autoreconf -ivf
      CC=${CC} LDFLAGS=${LDFLAGS} \
      ./configure --host=${HOST} --build=$(./config/config.guess) --enable-docs=no --enable-shared=no --enable-static=yes --prefix=/ --with-oniguruma=${cwd}/ios/onig/${arch} $(test -z ${BISON+x} && echo '--disable-maintainer-mode')
-     make -j${MAKEJOBS} install DESTDIR="${cwd}/ios/jq/${arch}"  # No jobs on purpose.
+     make -j${MAKEJOBS} install DESTDIR="${cwd}/ios/jq/${arch}"
      make clean
  done
 


### PR DESCRIPTION
Rewrites compile-ios.h, fixes error about lgamma_r being undefined in C99 (fixes #1936)

Allow for arguments to append to CFLAGS, LDFLAGS, and choose oniguruma version.

