### PR TITLE
Change Homebrew version in docs to 1.6

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -57,7 +57,7 @@ body:
 
       ### OS X
 
-       * Use [Homebrew](http://brew.sh/) to install jq 1.5 with
+       * Use [Homebrew](http://brew.sh/) to install jq 1.6 with
          `brew install jq`.
 
        * jq 1.6 binary for


### PR DESCRIPTION
Stable version is now 1.6 for [jq formula](https://formulae.brew.sh/formula/jq)