### PR TITLE
Updating Homebrew jq version on website

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -109,7 +109,7 @@
 
 <ul>
 <li>
-<p>Use <a href="http://brew.sh/">Homebrew</a> to install jq 1.5 with <code>brew install jq</code>.</p>
+<p>Use <a href="http://brew.sh/">Homebrew</a> to install jq 1.6 with <code>brew install jq</code>.</p>
 </li>
 
 <li>


### PR DESCRIPTION
According to [Homebrew](https://formulae.brew.sh/formula/jq#default) it will now install version 1.6 of `jq`. This PR updates the website to reflect this change to make it clear to users that installing from [Homebrew](https://formulae.brew.sh/formula/jq#default) will get you the latest version of `jq`.