### PR TITLE
Makefile: prepend srcdir to jq.1.prebuilt to fix out of source builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -169,7 +169,7 @@ else
 endif
 
 jq.1: jq.1.prebuilt
-	$(AM_V_GEN) cp jq.1.prebuilt $@
+	$(AM_V_GEN) cp $(srcdir)/jq.1.prebuilt $@
 
 ### Build oniguruma
 


### PR DESCRIPTION
Seems https://github.com/stedolan/jq/commit/50a7022ea68fb37faefdcd7a35661df72fbfd655 reverted a change and broke jq out of source builds
https://github.com/m-ab-s/media-autobuild_suite/issues/1567