### PR TITLE
Fix typo in manual's truthiness clarification

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -2065,7 +2065,8 @@ sections:
           means that you'll sometimes have to be more explicit about
           the condition you want.  You can't test whether, e.g. a
           string is empty using `if .name then A else B end`, you'll
-          need something more like `if .name then A else B end` instead.
+          need something more like `if (.name | length) > 0 then A else B end`
+          instead.
 
           If the condition `A` produces multiple results, then `B` is evaluated
           once for each result that is not false or null, and `C` is evaluated


### PR DESCRIPTION
At some point, the aside about truthiness in the dev manual was changed to remove the check for a nonempty string, making the "correct" version the same as the incorrect one. This just changes it back to the old `if (.name | length) > 0 ...` version.

`if .name != "" then A else B` would also work, without also treating e.g. `null` as an empty string, but the `length` one is preferred in the other manual versions.