### PR TITLE
Add minimal shell.nix to support nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,6 @@ with (import <nixpkgs> {});
 mkShell {
   name = "jq";
   buildInputs = [
-    git cacert cmake automake autoconf libtool
+    git cacert cmake automake autoconf libtool flex bison
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,6 @@ with (import <nixpkgs> {});
 stdenv.mkDerivation {
   name = "jq";
   buildInputs = [
-    git cacert cmake automake autoconf oniguruma libtool
+    git cacert cmake automake autoconf libtool
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,6 @@
 with (import <nixpkgs> {});
 
 mkShell {
-  name = "jq";
   buildInputs = [
     git cacert cmake automake autoconf libtool flex bison
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 with (import <nixpkgs> {});
 
-stdenv.mkDerivation {
+mkShell {
   name = "jq";
   buildInputs = [
     git cacert cmake automake autoconf libtool

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+with (import <nixpkgs> {});
+
+stdenv.mkDerivation {
+  name = "jq";
+  buildInputs = [
+    git cacert cmake automake autoconf oniguruma libtool
+  ];
+}


### PR DESCRIPTION
## Rationale

`nix-shell` is essentially a fast way to get from _"I just cloned this repo"_ to _"I just built the binary"_ without having to deal with tracking down build dependencies. It has helped me in the past (eg when building https://github.com/qmk/qmk_firmware) and I hope this will help others.

The one prerequisite to get this to work is to install https://nixos.org/nix/.

## Tested on

- macOS Mojave 10.14.6
- [Pop!_OS](https://system76.com/pop) (pretty much Ubuntu) 19.10

## Tested with

```sh
nix-shell --pure # this brings up a shell with only the build dependencies available

git submodule update --init
autoreconf -fi
./configure --with-oniguruma=builtin # and with --disable-maintainer-mode
make -j8 # and with LDFLAGS=-all-static
make check
```

## Todo

- [x] Add `shell.nix`
- [ ] Wait for a green light from one of the maintainers to proceed with the following
- [ ] Mention on README
- [ ] Add to CI