### PR TITLE
Fix error handling of f_gmtime in strftime

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1532,6 +1532,10 @@ static jv f_localtime(jq_state *jq, jv a) {
 static jv f_strftime(jq_state *jq, jv a, jv b) {
   if (jv_get_kind(a) == JV_KIND_NUMBER) {
     a = f_gmtime(jq, a);
+    if (!jv_is_valid(a)) {
+      jv_free(b);
+      return a;
+    }
   } else if (jv_get_kind(a) != JV_KIND_ARRAY) {
     return ret_error2(a, b, jv_string("strftime/1 requires parsed datetime inputs"));
   } else if (jv_get_kind(b) != JV_KIND_STRING) {


### PR DESCRIPTION
This pull request fixes #2123, assertion failure after an error in `f_gmtime`.

```sh
 % jq --version
jq-master-50a7022
 % jq -n "146162525339300000 | strftime(\"%Y-%m-%d\")"
Assertion failed: (JVP_HAS_KIND(j, JV_KIND_ARRAY)), function jv_array_get, file src/jv.c, line 684.
zsh: abort      jq -n "146162525339300000 | strftime(\"%Y-%m-%d\")"
 % ./jq -n "146162525339300000 | strftime(\"%Y-%m-%d\")"
jq: error (at <unknown>): error converting number of seconds since epoch to datetime
```