### PR TITLE
Fix TravisCI build stage failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: bionic
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ jobs:
 
             install:
                 - pyenv global 3.6.7
-                - pip3 install pipenv
+                - pip3 install "pipenv==2018.11.26" # https://github.com/pypa/pipenv/issues/4273
                 - pushd docs && pipenv sync && popd
                 - if [ -n "$COVERAGE" ]; then pip install --user cpp-coveralls; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ jobs:
                 - sudo sh alpine-chroot-install -b v3.7 -a "$ARCH"
                     -p 'build-base automake autoconf bison git libtool oniguruma-dev python3 python3-dev libxml2-dev libxslt-dev'
                 - /alpine/enter-chroot pip3 install pipenv
-                - alpine sh -c 'cd docs && pipenv sync'
+                - alpine sh -c 'cd docs && pipenv sync --verbose'
 
             before_script:
                 - autoreconf -if

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
 
             before_install:
                 - uname -s
+                - sh -c "cd $(pyenv root) && git switch master && git pull"
                 - pyenv install -s 3.6.7
                 - rm src/{lexer,parser}.{c,h}
                 - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac


### PR DESCRIPTION
This pull request **tries to** fix #2132. I updated the Ubuntu version. Please confirm the CI result [here](https://travis-ci.org/github/itchyny/jq/builds/694148135) (because the build stage is disabled on pull requests). The build failure due to installation of `qemu-user-static` is fixed, but the build still fails with `pipenv sync` hanging (see the [CI status](https://travis-ci.org/github/itchyny/jq/builds/694148135)). Quick googling leads me to [some](https://github.com/pypa/pipenv/issues/3827) [issues](https://github.com/pypa/pipenv/issues/1816) and I tried `env PIP_NO_CACHE_DIR=false` but it also failed. I'm not familiar with the ecosystem of Python but should we go back to pip+requirements.txt?

BTW The AppVeyor CI fails due to different reason, sigh.
ping @NinjaMac @wtlangford 