### PR TITLE
Fix build on aarch64 Darwin

### DIFF
--- a/compile-ios.sh
+++ b/compile-ios.sh
@@ -74,7 +74,7 @@ cd "${builddir}/"
      HOST="${arch}-apple-darwin"
      [[ "${arch}" = "arm64" ]] && HOST="aarch64-apple-darwin"
 
-     CFLAGS="-arch ${arch} -miphoneos-version-min=9.0 -isysroot ${SYSROOT} ${CFLAGS_} -D_REENTRANT"
+     CFLAGS="-arch ${arch} -miphoneos-version-min=9.0 -isysroot ${SYSROOT} ${CFLAGS_}"
      LDFLAGS="-arch ${arch} -miphoneos-version-min=9.0 -isysroot ${SYSROOT} ${LDFLAGS_}"
      CC="${CC_} ${CFLAGS}"
 

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -28,6 +28,9 @@ void *alloca (size_t);
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
+#ifdef __APPLE__
+#define _REENTRANT
+#endif
 #include <math.h>
 #ifdef HAVE_LIBONIG
 #include <oniguruma.h>


### PR DESCRIPTION
Apple's platforms want _REENTRANT defined before they declare the *_r functions in math.h. On x86_64 this merely caused a warning, but on aarch64 -Wimplicit-function-declaration has been bumped up to an error.