### PR TITLE
Add large file support for 32-bit systems to fix issue 2167

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_EXEEXT
 LT_INIT([shared static win32-dll])
 AM_PROG_CC_C_O
 
+AC_SYS_LARGEFILE # issue 2167
 
 dnl couldn't use AM_PROG_LEX as it doesn't support header files like the
 dnl AC_PROG_YACC macros...


### PR DESCRIPTION
I've added ```AC_SYS_LARGEFILE``` to ```jq/configure.ac```, to fix [issue 2167](https://github.com/stedolan/jq/issues/2167). This will ```#define _FILE_OFFSET_BITS 64``` when required, so jq on 32-bit platforms can ```stat()``` files on 64-bit filesystems.