### PR TITLE
Fix msys2 installation on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ clone_script:
 
 install:
   # update msys2
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - ps: Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex git"


### PR DESCRIPTION
This pull request fixes CI on AppVeyor.
Ref: https://www.msys2.org/news/#2020-06-29-new-packagers