### PR TITLE
Fix extended regex pattern example

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -2260,7 +2260,7 @@ sections:
 
       To match whitespace in an x pattern use an escape such as \s, e.g.
 
-      * test( "a\\sb", "x" ).
+      * test( "a\\\\sb"; "x" )
 
       Note that certain flags may also be specified within REGEX, e.g.
 

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -1987,7 +1987,7 @@ sections:
 
       To match whitespace in an x pattern use an escape such as \s, e.g.
 
-      * test( "a\\sb", "x" ).
+      * test( "a\\\\sb"; "x" )
 
       Note that certain flags may also be specified within REGEX, e.g.
 

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -2280,7 +2280,7 @@ sections:
 
       To match whitespace in an x pattern use an escape such as \s, e.g.
 
-      * test( "a\\sb", "x" ).
+      * test( "a\\\\sb"; "x" )
 
       Note that certain flags may also be specified within REGEX, e.g.
 


### PR DESCRIPTION
`test( "a\sb", "x" )`  as it appears in the manual was doubly erroneous 
- `\s` in a string literal should be escaped as `\\s`
- The argument delimiter should be `;` instead of `,`
