### PR TITLE
Added repeat/2 and repeated/2

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -195,6 +195,8 @@ def repeat(exp):
      def _repeat:
          exp, _repeat;
      _repeat;
+def repeat(exp,reps):
+    limit(reps ; repeat(exp))
 def inputs: try repeat(input) catch if .=="break" then empty else error end;
 # like ruby's downcase - only characters A to Z are affected
 def ascii_downcase:

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -198,7 +198,7 @@ def repeat(exp):
 def repeat(exp ; reps):
     limit(reps ; repeat(exp))
 def repeated(exp ; reps):
-    repeat(exp ; reps) | add
+    [repeat(exp ; reps)] | add
 def inputs: try repeat(input) catch if .=="break" then empty else error end;
 # like ruby's downcase - only characters A to Z are affected
 def ascii_downcase:

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -195,8 +195,10 @@ def repeat(exp):
      def _repeat:
          exp, _repeat;
      _repeat;
-def repeat(exp,reps):
+def repeat(exp ; reps):
     limit(reps ; repeat(exp))
+def repeated(exp ; reps):
+    repeat(exp ; reps) | add
 def inputs: try repeat(input) catch if .=="break" then empty else error end;
 # like ruby's downcase - only characters A to Z are affected
 def ascii_downcase:


### PR DESCRIPTION
Instead of having to use `limit/2`, repeat can now trunctuate the output to a specific number. Examples:

```
repeat([1,2,3];3) ->
[
  1,
  2,
  3
]
[
  1,
  2,
  3
]
[
  1,
  2,
  3
]
```

`repeated/2` joins the output of `repeat/2` with `|add`, just like in JavaScript.