### PR TITLE
Update the version available through Chocolatey

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -100,7 +100,7 @@ body:
 
       ### Windows
 
-       * Use [Chocolatey NuGet](https://chocolatey.org/) to install jq 1.5 with
+       * Use [Chocolatey NuGet](https://chocolatey.org/) to install jq 1.6 with
          `chocolatey install jq`.
 
        * jq 1.6 executables for


### PR DESCRIPTION
Version 1.6 has been available [through Chocolatey](https://chocolatey.org/packages/jq) for quite a while. I forgot to update the docs when bumping it! : )