### PR TITLE
MacOSX fix for lgamma_r function.

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -28,6 +28,9 @@ void *alloca (size_t);
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
+#ifdef __APPLE__
+#define _REENTRANT
+#endif
 #include <math.h>
 #ifdef HAVE_LIBONIG
 #include <oniguruma.h>


### PR DESCRIPTION
The lgamma_r needs to be requested explicitly on OS X.

From the man page:
> In order to use the lgamma_r() function, define the macro _REENTRANT before including
<math.h>
This fixes the build on OS X, which is particularly useful for those wanting to build
a version to run natively on Apple Silicon.