### PR TITLE
Move the IRC channel to Libera.Chat

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ about: Create a report to help us improve
 <!--
 READ THIS FIRST!
 
-If you have a usage question, please ask us on either Stack Overflow (https://stackoverflow.com/questions/tagged/jq) or in the #jq channel (http://irc.lc/freenode/%23jq/) on Freenode (https://webchat.freenode.net/).
+If you have a usage question, please ask us on either Stack Overflow (https://stackoverflow.com/questions/tagged/jq) or in the #jq channel (https://web.libera.chat/#jq) on Libera.Chat (https://libera.chat/).
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Cross-compilation requires a clean workspace, then:
     scripts/crosscompile <name-of-build> <configure-options>
 
 Use the `--host=` and `--target=` ./configure options to select a
-cross-compilation environment.  See also 
+cross-compilation environment.  See also
 ["Cross compilation"](https://github.com/stedolan/jq/wiki/Cross-compilation) on
 the wiki.
 
-Send questions to https://stackoverflow.com/questions/tagged/jq or to the #jq channel (http://irc.lc/freenode/%23jq/) on Freenode (https://webchat.freenode.net/).
+Send questions to https://stackoverflow.com/questions/tagged/jq or to the #jq channel (https://web.libera.chat/#jq) on Libera.Chat (https://libera.chat/).

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -29,8 +29,7 @@ tail: |
 
   Ask questions on [stackoverflow](https://stackoverflow.com/) using the [jq
   tag](https://stackoverflow.com/questions/tagged/jq), or on the
-  [#jq](http://irc.lc/freenode/%23jq/) channel on
-  [Freenode](https://webchat.freenode.net/).
+  [#jq](https://web.libera.chat/#jq) channel on [Libera.Chat](https://libera.chat/).
 
 news:
   - date: 1 November 2018


### PR DESCRIPTION
As you might be aware, a lot of open source communities have begun migrating away from freenode to [Libera.Chat](https://libera.chat/) (same staff, different administrative foundation) after recent events. In particular, the most active helpers in `#jq` (`nf` (me), `geirha` (@geirha) and `earnestly` (@Earnestly)) have moved out.

This PR updates the documentation to point at the new network.

P.S. @wtlangford, @nicowilliams, ping me on Libera if you'd like founder access to `#jq`.