### PR TITLE
Add --recursive to git clone

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -154,7 +154,7 @@ body:
 
       If you're interested in using the lastest development version, try:
 
-          git clone https://github.com/stedolan/jq.git
+          git clone --recursive https://github.com/stedolan/jq.git
           cd jq
           autoreconf -i
           ./configure --disable-maintainer-mode


### PR DESCRIPTION
Without the recursive option, the `oniguruma` submodule cannot be found.

Error message:
```
make  all-recursive
make[1]: Entering directory '/path/to/jq'
Making all in modules/oniguruma
make[2]: Entering directory '/path/to/jq/modules/oniguruma'
make[2]: *** No rule to make target 'all'.  Stop.
make[2]: Leaving directory '/path/to/jq/modules/oniguruma'
make[1]: *** [Makefile:1144: all-recursive] Error 1
make[1]: Leaving directory '/path/to/jq'
make: *** [Makefile:780: all] Error 2
```