### PR TITLE
docs(manual): fix the typo errors in the manual

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -256,7 +256,7 @@ sections:
 
         This option reads in the named file and binds its contents to the given
         global variable.  If you run jq with `--rawfile foo bar`, then `$foo` is
-        available in the program and has a string whose contents are to the texs
+        available in the program and has a string whose contents are to the texts
         in the file named `bar`.
 
       * `--argfile variable-name filename`:

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -244,7 +244,7 @@ sections:
 
         This option reads in the named file and binds its contents to the given
         global variable.  If you run jq with `--rawfile foo bar`, then `$foo` is
-        available in the program and has a string whose contents are to the texs
+        available in the program and has a string whose contents are to the texts
         in the file named `bar`.
 
       * `--argfile variable-name filename`:


### PR DESCRIPTION
fix the manual typo errors in manual v1.6 and main manual file.