### PR TITLE
Document the potential security issues when using `-r`/`-0`.

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -196,6 +196,11 @@ sections:
         making jq filters talk to non-JSON-based systems. The output
         values will be separated by a newline (`\n` aka LF) character.
 
+        Please note a **potential security issue** when using this option.
+        Please note that if the selected data of the input JSON contains
+        newline characters then processing of jq output will incorrectly
+        split a single item containing an newline character into two items.
+
       * `--join-output` / `-j`:
 
         Like `-r` but jq won't print a newline after each output.

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -193,7 +193,8 @@ sections:
         With this option, if the filter's result is a string then it
         will be written directly to standard output rather than being
         formatted as a JSON string with quotes. This can be useful for
-        making jq filters talk to non-JSON-based systems.
+        making jq filters talk to non-JSON-based systems. The output
+        values will be separated by a newline (`\n` aka LF) character.
 
       * `--join-output` / `-j`:
 

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -210,6 +210,11 @@ sections:
         Like `-r` but jq will print NUL instead of newline after each output.
         This can be useful when the values being output can contain newlines.
 
+        Please note a **potential security issue** when using this option.
+        Please note that if the selected data of the input JSON contains
+        NUL (`"\u0000"`) characters then programs processing jq output will
+        incorrectly split an item containing a NUL character into two items.
+
       * `-f filename` / `--from-file filename`:
 
         Read filter from the file rather than from a command line, like

--- a/docs/content/manual/v1.3/manual.yml
+++ b/docs/content/manual/v1.3/manual.yml
@@ -126,7 +126,8 @@ sections:
         With this option, if the filter's result is a string then it
         will be written directly to standard output rather than being
         formatted as a JSON string with quotes. This can be useful for
-        making jq filters talk to non-JSON-based systems.
+        making jq filters talk to non-JSON-based systems. The output
+        values will be separated by a newline (`\n` aka LF) character.
 
       * `--arg name value`:
 

--- a/docs/content/manual/v1.3/manual.yml
+++ b/docs/content/manual/v1.3/manual.yml
@@ -129,6 +129,11 @@ sections:
         making jq filters talk to non-JSON-based systems. The output
         values will be separated by a newline (`\n` aka LF) character.
 
+        Please note a **potential security issue** when using this option.
+        Please note that if the selected data of the input JSON contains
+        newline characters then processing of jq output will incorrectly
+        split a single item containing an newline character into two items.
+
       * `--arg name value`:
 
         This option passes a value to the jq program as a predefined

--- a/docs/content/manual/v1.4/manual.yml
+++ b/docs/content/manual/v1.4/manual.yml
@@ -160,6 +160,11 @@ sections:
         making jq filters talk to non-JSON-based systems. The output
         values will be separated by a newline (`\n` aka LF) character.
 
+        Please note a **potential security issue** when using this option.
+        Please note that if the selected data of the input JSON contains
+        newline characters then processing of jq output will incorrectly
+        split a single item containing an newline character into two items.
+
       * `-f filename` / `--from-file filename`:
 
         Read filter from the file rather than from a command line, like

--- a/docs/content/manual/v1.4/manual.yml
+++ b/docs/content/manual/v1.4/manual.yml
@@ -157,7 +157,8 @@ sections:
         With this option, if the filter's result is a string then it
         will be written directly to standard output rather than being
         formatted as a JSON string with quotes. This can be useful for
-        making jq filters talk to non-JSON-based systems.
+        making jq filters talk to non-JSON-based systems. The output
+        values will be separated by a newline (`\n` aka LF) character.
 
       * `-f filename` / `--from-file filename`:
 

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -183,7 +183,8 @@ sections:
         With this option, if the filter's result is a string then it
         will be written directly to standard output rather than being
         formatted as a JSON string with quotes. This can be useful for
-        making jq filters talk to non-JSON-based systems.
+        making jq filters talk to non-JSON-based systems. The output
+        values will be separated by a newline (`\n` aka LF) character.
 
       * `--join-output` / `-j`:
 

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -186,6 +186,11 @@ sections:
         making jq filters talk to non-JSON-based systems. The output
         values will be separated by a newline (`\n` aka LF) character.
 
+        Please note a **potential security issue** when using this option.
+        Please note that if the selected data of the input JSON contains
+        newline characters then processing of jq output will incorrectly
+        split a single item containing an newline character into two items.
+
       * `--join-output` / `-j`:
 
         Like `-r` but jq won't print a newline after each output.

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -189,6 +189,11 @@ sections:
         making jq filters talk to non-JSON-based systems. The output
         values will be separated by a newline (`\n` aka LF) character.
 
+        Please note a **potential security issue** when using this option.
+        Please note that if the selected data of the input JSON contains
+        newline characters then processing of jq output will incorrectly
+        split a single item containing an newline character into two items.
+
       * `--join-output` / `-j`:
 
         Like `-r` but jq won't print a newline after each output.

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -186,7 +186,8 @@ sections:
         With this option, if the filter's result is a string then it
         will be written directly to standard output rather than being
         formatted as a JSON string with quotes. This can be useful for
-        making jq filters talk to non-JSON-based systems.
+        making jq filters talk to non-JSON-based systems. The output
+        values will be separated by a newline (`\n` aka LF) character.
 
       * `--join-output` / `-j`:
 


### PR DESCRIPTION
Also document how `-r` does separators.

Reported-by: @pcworld
Reported-in: https://github.com/stedolan/jq/issues/1271#issuecomment-920835007