### PR TITLE
Cppcheck fix: Missing "va_end" call. 

### DIFF
--- a/src/locfile.c
+++ b/src/locfile.c
@@ -72,6 +72,7 @@ void locfile_locate(struct locfile* l, location loc, const char* fmt, ...) {
   }
 
   jv m1 = jv_string_vfmt(fmt, fmtargs);
+  va_end(fmtargs);
   if (!jv_is_valid(m1)) {
     jq_report_error(l->jq, m1);
     return;


### PR DESCRIPTION
This was found by running the cppcheck static analysis where it shows as error.

There should be "va_end" call for every "va_start" according to  http://en.cppreference.com/w/c/variadic/va_end.