### PR TITLE
Fix AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,10 @@ install:
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
 
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.6.4-1-x86_64.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.6.4-1-x86_64.pkg.tar.zst"
 
   - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,26 +12,31 @@ clone_script:
 
 install:
   # update msys2
+  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
+
+  # update dependencies
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
 
-  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://gnu.mirror.constant.com/bison/bison-3.5.1.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://gnu.mirror.constant.com/bison/bison-3.5.1.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.5.1.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.5.1.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.6.4-1-x86_64.pkg.tar.zst"
 
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm flex-2.6.4-1-x86_64.pkg.tar.xz"
+  
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex git"
 
   #- C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/git-2.33.1-1-x86_64.pkg.tar.zst"
   - ps: Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process
-  #- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
-  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
-  #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex git"
+
+  # create venv
   - C:\msys64\usr\bin\bash -lc "pip3 install --upgrade pipenv"
   - C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER/docs && pipenv sync"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,17 +14,20 @@ install:
   # update msys2
   - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.5.4-1-x86_64.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.5.4-1-x86_64.pkg.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
-  #- C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/git-2.33.1-1-x86_64.pkg.tar.zst"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.5.4-1-x86_64.pkg.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.5.4-1-x86_64.pkg.tar.xz"
+
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.6.4-1-x86_64.pkg.tar.xz"
+
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm flex-2.6.4-1-x86_64.pkg.tar.xz"
+
+  #- C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/git-2.33.1-1-x86_64.pkg.tar.zst"
   - ps: Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process
   #- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,16 +11,17 @@ clone_script:
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && git submodule update --init --recursive"
 
 install:
-  # update msys2
-  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
-
-  # update dependencies
+  # accept new maintainers
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
 
+  # update msys2
+  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
+
+  # update dependencies
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.zst.sig"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ install:
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
 
   # update msys2
-  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
+  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
 
   # update dependencies
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 environment:
   matrix:
   - MSYSTEM: MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ install:
 
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://gnu.mirror.constant.com/bison/bison-3.5.1.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://gnu.mirror.constant.com/bison/bison-3.5.1.tar.xz.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.5.1.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.5.1.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.5.1.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.5.1.tar.xz"
 
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,22 +12,22 @@ clone_script:
 
 install:
   # update msys2
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
 
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.6.4-1-x86_64.pkg.tar.zst"
 
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
-  - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify flex-2.6.4-1-x86_64.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm flex-2.6.4-1-x86_64.pkg.tar.xz"
 
-  #- C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/git-2.33.1-1-x86_64.pkg.tar.zst"
+  #- C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/git-2.33.1-1-x86_64.pkg.tar.zst"
   - ps: Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process
   #- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   #- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,10 @@ install:
   - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
   - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
 
-  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst"
-  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.6.4-1-x86_64.pkg.tar.zst.sig"
-  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.6.4-1-x86_64.pkg.tar.zst"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://gnu.mirror.constant.com/bison/bison-3.5.1.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "curl -O --fail http://gnu.mirror.constant.com/bison/bison-3.5.1.tar.xz.sig"
+  - C:\msys64\usr\bin\bash -lc "pacman-key --verify bison-3.5.1.tar.xz"
+  - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm bison-3.5.1.tar.xz.sig"
 
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz"
   - C:\msys64\usr\bin\bash -lc "curl -O --fail http://repo.msys2.org/msys/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz.sig"


### PR DESCRIPTION
Noticed on my previous PR that the CI's red, so thought I'd try to fix it. The AppVeyor setup is trying to pull a version of bison that's no longer available on the msys2 repo (http://repo.msys2.org/msys/x86_64/ no longer contains `bison-3.5.4-1`).

Note also that Travis is no longer running Linux builds because of #2318.