### PR TITLE
fixes incorrect example in man page

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -116,7 +116,7 @@ sections:
         Parse the input in streaming fashion, outputting arrays of path
         and leaf values (scalars and empty arrays or empty objects).
         For example, `"a"` becomes `[[],"a"]`, and `[[],"a",["b"]]`
-        becomes `[[0],[]]`, `[[1],"a"]`, and `[[1,0],"b"]`.
+        becomes `[[0],[]]`, `[[1],"a"]`, and `[[2,0],"b"]`.
 
         This is useful for processing very large inputs.  Use this in
         conjunction with filtering and the `reduce` and `foreach` syntax


### PR DESCRIPTION
Might also want to add the "closing" paths at the end (`[[2,0]]` and `[[2]]`)