### PR TITLE
feat: `dig(<string>)` extracts from a nested index

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -393,6 +393,28 @@ sections:
           `.["foo"]` (.foo above is a shorthand version of this, but
           only for identifier-like strings).
 
+      - title: "Dig for Generic Object Index: `dig(<string>)`"
+
+        body: |
+
+          `dig("foo")` behaves almost the same as `.["foo"]` but it
+          can dig down through a sequence of keys obtained from
+          spliting `<string>` on `"."`.
+
+          ie. so `dig("foo.bar")` is equivalent to .["foo"]["bar"]`.
+          (Which is not the same as `.["foo.bar"]`)
+
+        examples:
+          - program: 'dig("a.b")'
+            input: '{"a": {"b": 42}}'
+            output: ['42']
+          - program: 'dig("a")'
+            input: '{"a": {"b": 42}}'
+            output: ['{"b": 42}']
+          - program: 'dig("a.b")'
+            input: '{"a.b": 42}'
+            output: ['null']
+
       - title: "Array Index: `.[2]`"
         body: |
 

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -42,6 +42,7 @@ def to_entries: [keys_unsorted[] as $k | {key: $k, value: .[$k]}];
 def from_entries: map({(.key // .Key // .name // .Name): (if has("value") then .value else .Value end)}) | add | .//={};
 def with_entries(f): to_entries | map(f) | from_entries;
 def reverse: [.[length - 1 - range(0;length)]];
+def dig($path): reduce ($path | split("."))[] as $key (.; .[$key]);
 def indices($i): if type == "array" and ($i|type) == "array" then .[$i]
   elif type == "array" then .[[$i]]
   elif type == "string" and ($i|type) == "string" then _strindices($i)


### PR DESCRIPTION
`dig("foo")` behaves almost the same as `.["foo"]` but it
can dig down through a sequence of keys obtained from
spliting `<string>` on `"."`.

ie. so `dig("foo.bar")` is equivalent to `.["foo"]["bar"]`.
(although not the same as `.["foo.bar"]`)

(Nb. named after ruby's [dig](https://apidock.com/ruby/Hash/dig))