### PR TITLE
docs(manual): fix `--stream` typo

### DIFF
--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -115,7 +115,7 @@ sections:
         Parse the input in streaming fashion, outputting arrays of path
         and leaf values (scalars and empty arrays or empty objects).
         For example, `"a"` becomes `[[],"a"]`, and `[[],"a",["b"]]`
-        becomes `[[0],[]]`, `[[1],"a"]`, and `[[1,0],"b"]`.
+        becomes `[[0],[]]`, `[[1],"a"]`, and `[[2,0],"b"]`.
 
         This is useful for processing very large inputs.  Use this in
         conjunction with filtering and the `reduce` and `foreach` syntax


### PR DESCRIPTION
this fixes a small typo that had me confused about `--stream` initially