### PR TITLE
docs: parenthesize key expression to compile

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -599,9 +599,8 @@ sections:
           If the keys are "identifier-like", then the quotes can be left
           off, as in `{a:42, b:17}`.  Variable references as key
           expressions use the value of the variable as the key.  Key
-          expressions other than constant literals, identifiers, or
-          variable references, need to be parenthesized, e.g.,
-          `{("a"+"b"):59}`.
+          expressions other than constant literals or identifiers need
+          to be parenthesized, e.g. `{("a"+"b"):59}`.
 
           The value can be any expression (although you may need to wrap
           it in parentheses if, for example, it contains colons), which

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -648,7 +648,7 @@ sections:
           the key.  Without a value then the variable's name becomes the
           key and its value becomes the value,
 
-              "f o o" as $foo | "b a r" as $bar | {$foo, $bar:$foo}
+              "f o o" as $foo | "b a r" as $bar | {$foo, ($bar):$foo}
 
           produces
 


### PR DESCRIPTION
Before this change the example does not compile:

```
jq: error: syntax error, unexpected ':', expecting '}' (Unix shell quoting issues?) at <top-level>, line 1:
"f o o" as $foo | "b a r" as $bar | {$foo, $bar:$foo}                                               
jq: error: May need parentheses around object key expression at <top-level>, line 1:
"f o o" as $foo | "b a r" as $bar | {$foo, $bar:$foo}                                     
jq: 2 compile errors
exit status 3
```

After this change the output is produced as expected.