### PR TITLE
jq.test: drop non-portable %F test

### DIFF
--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1848,10 +1848,6 @@ try ["OK", strflocaltime({})] catch ["KO", .]
 "2015-03-05T23:51:47Z"
 [[2015,2,5,23,51,47,4,63],1425599507]
 
-[strptime("%FT%T")|(.,mktime)]
-"2025-06-07T08:09:10"
-[[2025,5,7,8,9,10,6,157],1749283750]
-
 # Check day-of-week and day of year computations
 # (should trip an assert if this fails)
 last(range(365 * 67)|("1970-03-01T01:02:03Z"|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime) + (86400 * .)|strftime("%Y-%m-%dT%H:%M:%SZ")|strptime("%Y-%m-%dT%H:%M:%SZ"))


### PR DESCRIPTION
%F is a non-portable GNU extension, not supported by all strptime implementations (for example musl's).