### PR TITLE
Add fromwebkit and toreadable builtins for forensic analysis

### DIFF
--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -2298,6 +2298,21 @@ sections:
           some systems. In particular, the `%u` and `%j` specifiers for
           `strptime(fmt)` are not supported on macOS.
 
+          The `fromwebkit` builtin converts WebKit/Chromium timestamp format
+          (microseconds since January 1, 1601 UTC) to ISO 8601 format. This is
+          commonly used in browser forensics when analyzing Chrome, Safari, Edge,
+          and other Chromium-based browser artifacts. The function validates
+          input ranges and handles null values. Zero values return null, and
+          negative or out-of-range values produce errors.
+    
+          The `toreadable` builtin converts ISO 8601 timestamp strings or Unix
+          timestamps to human-readable format "YYYY-MM-DD HH:MM:SS". For numeric
+          inputs, it automatically detects whether the value represents seconds
+          or milliseconds and converts accordingly. The function strictly validates
+          input and produces errors for malformed or out-of-range values rather
+          than silently passing them through. This makes it suitable for data
+          validation pipelines where invalid timestamps should be caught.
+
         examples:
           - program: 'fromdate'
             input: '"2015-03-05T23:51:47Z"'
@@ -2310,6 +2325,30 @@ sections:
           - program: 'strptime("%Y-%m-%dT%H:%M:%SZ")|mktime'
             input: '"2015-03-05T23:51:47Z"'
             output: ['1425599507']
+
+          - program: "fromwebkit"
+            input: "13318523932000000"
+            output: ['"2023-03-15T14:32:12Z"']
+    
+          - program: "fromwebkit"
+            input: "0"
+            output: ["null"]
+    
+          - program: "toreadable"
+            input: '"2020-01-01T23:43:12.123456+05:00"'
+            output: ['"2020-01-01 23:43:12"']
+    
+          - program: "toreadable"
+            input: "1577919792"
+            output: ['"2020-01-01 23:03:12"']
+    
+          - program: "toreadable"
+            input: "1577919792000"
+            output: ['"2020-01-01 23:03:12"']
+    
+          - program: 'map(toreadable)'
+            input: '[1577919792, "2020-01-01T23:43:12Z", null]'
+            output: ['["2020-01-01 23:03:12", "2020-01-01 23:43:12", null]']
 
       - title: "SQL-Style Operators"
         body: |
@@ -3856,3 +3895,4 @@ sections:
         - 35 (magenta)
         - 36 (cyan)
         - 37 (white)
+

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -241,3 +241,61 @@ def JOIN($idx; stream; idx_expr; join_expr):
   stream | [., $idx[idx_expr]] | join_expr;
 def IN(s): any(s == .; .);
 def IN(src; s): any(src == s; .);
+
+# Convert WebKit timestamp (Chrome/Safari) to ISO 8601
+def fromwebkit:
+  if type == "number" then
+    if . < 0 then
+      error("fromwebkit: timestamp cannot be negative")
+    elif . == 0 then
+      null
+    elif . > 265000000000000000 then
+      error("fromwebkit: timestamp out of valid range")
+    else
+      ((. / 1000000) - 11644473600) | todateiso8601
+    end
+  elif . == null then
+    null
+  else
+    error("fromwebkit: input must be number or null")
+  end;
+
+# Convert timestamps to human-readable format
+def toreadable:
+  if type == "string" then
+    if test("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}") then
+      split("T") as $parts |
+      if ($parts | length) == 2 then
+        $parts[0] + " " + (
+          $parts[1] 
+          | split(".")[0]
+          | split("Z")[0]
+          | split("+")[0]
+          | split("-")[0]
+          | if test("^\\d{2}:\\d{2}:\\d{2}$") then . else split("-")[0] end
+        )
+      else
+        error("toreadable: malformed ISO 8601 timestamp")
+      end
+    else
+      error("toreadable: input string must be valid ISO 8601 format")
+    end
+  elif type == "number" then
+    if . < 0 then
+      error("toreadable: timestamp cannot be negative")
+    elif . == 0 then
+      null
+    elif . > 253402300799000 then
+      error("toreadable: timestamp out of valid range")
+    else
+      if . > 9999999999 then
+        (. / 1000 | todateiso8601 | toreadable)
+      else
+        (todateiso8601 | toreadable)
+      end
+    end
+  elif . == null then
+    null
+  else
+    error("toreadable: input must be string, number, or null")
+  end;


### PR DESCRIPTION
- fromwebkit: Convert WebKit/Chromium timestamps to ISO 8601 Used in browser forensics (Chrome, Safari, Edge artifacts) Handles microseconds since 1601-01-01 with validation

- toreadable: Convert timestamps to human-readable format Auto-detects seconds vs milliseconds for Unix timestamps Strict error handling for invalid/malformed inputs

Both functions include comprehensive input validation for forensic analysis and data processing pipelines.