### PR TITLE
Fix stder typo

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3320,7 +3320,7 @@ sections:
       output as JSON texts on `stdout`.) The `debug` builtin can have
       application-specific behavior, such as for executables that use
       the libjq C API but aren't the jq executable itself.  The `stderr`
-      builtin outputs its input in raw mode to stder with no additional
+      builtin outputs its input in raw mode to stderr with no additional
       decoration, not even a newline.
 
       Most jq builtins are referentially transparent, and yield constant

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -2926,7 +2926,7 @@ sections:
       output as JSON texts on `stdout`.)  The `debug` builtin can have
       application-specific behavior, such as for executables that use
       the libjq C API but aren't the jq executable itself.  The `stderr`
-      builtin outputs its input in raw mode to stder with no additional
+      builtin outputs its input in raw mode to stderr with no additional
       decoration, not even a newline.
 
       Most jq builtins are referentially transparent, and yield constant

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -3226,7 +3226,7 @@ sections:
       output as JSON texts on `stdout`.) The `debug` builtin can have
       application-specific behavior, such as for executables that use
       the libjq C API but aren't the jq executable itself.  The `stderr`
-      builtin outputs its input in raw mode to stder with no additional
+      builtin outputs its input in raw mode to stderr with no additional
       decoration, not even a newline.
 
       Most jq builtins are referentially transparent, and yield constant

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -3320,7 +3320,7 @@ sections:
       output as JSON texts on `stdout`.) The `debug` builtin can have
       application-specific behavior, such as for executables that use
       the libjq C API but aren't the jq executable itself.  The `stderr`
-      builtin outputs its input in raw mode to stder with no additional
+      builtin outputs its input in raw mode to stderr with no additional
       decoration, not even a newline.
 
       Most jq builtins are referentially transparent, and yield constant

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3720,7 +3720,7 @@ See your system\'s manual for more information on each of these\.
 At this time jq has minimal support for I/O, mostly in the form of control over when inputs are read\. Two builtins functions are provided for this, \fBinput\fR and \fBinputs\fR, that read from the same sources (e\.g\., \fBstdin\fR, files named on the command\-line) as jq itself\. These two builtins, and jq\'s own reading actions, can be interleaved with each other\. They are commonly used in combination with the null input option \fB\-n\fR to prevent one input from being read implicitly\.
 .
 .P
-Two builtins provide minimal output capabilities, \fBdebug\fR, and \fBstderr\fR\. (Recall that a jq program\'s output values are always output as JSON texts on \fBstdout\fR\.) The \fBdebug\fR builtin can have application\-specific behavior, such as for executables that use the libjq C API but aren\'t the jq executable itself\. The \fBstderr\fR builtin outputs its input in raw mode to stder with no additional decoration, not even a newline\.
+Two builtins provide minimal output capabilities, \fBdebug\fR, and \fBstderr\fR\. (Recall that a jq program\'s output values are always output as JSON texts on \fBstdout\fR\.) The \fBdebug\fR builtin can have application\-specific behavior, such as for executables that use the libjq C API but aren\'t the jq executable itself\. The \fBstderr\fR builtin outputs its input in raw mode to stderr with no additional decoration, not even a newline\.
 .
 .P
 Most jq builtins are referentially transparent, and yield constant and repeatable value streams when applied to constant inputs\. This is not true of I/O builtins\.


### PR DESCRIPTION
The manual was missing an "r" in "stderr".