### PR TITLE
Fix for AIX optional testcase failure

### DIFF
--- a/tests/optional.test
+++ b/tests/optional.test
@@ -2,8 +2,8 @@
 
 # Regression test for #3276 (fails on mingw/WIN32)
 fromdate
-"2038-01-19T03:14:08Z"
-2147483648
+"2038-01-19T03:14:07Z"
+2147483647
 
 # %e is not available on mingw/WIN32
 strftime("%A, %B %e, %Y")


### PR DESCRIPTION
These changes are for fixing #3447 .

Due to 32bit unix time overflow, its going beyond time_t boundary resulting in **invalid gmtime representation** in 32bit mode for AIX.

```
echo '"2038-01-19T03:14:08Z"' | ./jq 'fromdate'
jq: error (at <stdin>:1): invalid gmtime representation

echo '"2038-01-19T03:14:07Z"' | ./jq 'fromdate'
2147483647
```