### PR TITLE
Limit number of function parameters and definitions to prevent SEGV

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -1244,7 +1244,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
       // Prevent subfunction index from overflowing into ARG_NEWCLOSURE flag
       if (bc->nsubfunctions == ARG_NEWCLOSURE) {
         locfile_locate(lf, curr->source,
-            "too many subfunctions/closures (max %d)", ARG_NEWCLOSURE - 1);
+            "too many function parameters or local function definitions (max %d)", ARG_NEWCLOSURE - 1);
         errors++;
       }
       curr->imm.intval = bc->nsubfunctions++;

--- a/src/compile.c
+++ b/src/compile.c
@@ -1242,10 +1242,11 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
     if (curr->op == CLOSURE_CREATE) {
       assert(curr->bound_by == curr);
       // Prevent subfunction index from overflowing into ARG_NEWCLOSURE flag
-      if (bc->nsubfunctions == ARG_NEWCLOSURE) {
+      if (bc->nsubfunctions >= ARG_NEWCLOSURE) {
         locfile_locate(lf, curr->source,
             "too many function parameters or local function definitions (max %d)", ARG_NEWCLOSURE - 1);
         errors++;
+        break;
       }
       curr->imm.intval = bc->nsubfunctions++;
     }
@@ -1281,7 +1282,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
           assert(param->op == CLOSURE_PARAM);
           assert(param->bound_by == param);
           // Prevent closure index from overflowing into ARG_NEWCLOSURE flag
-          if (subfn->nclosures == ARG_NEWCLOSURE) {
+          if (subfn->nclosures >= ARG_NEWCLOSURE) {
             locfile_locate(lf, curr->source,
                 "function has too many parameters (max %d)", ARG_NEWCLOSURE - 1);
             errors++;

--- a/tests/shtest
+++ b/tests/shtest
@@ -844,4 +844,31 @@ if ! $msys && ! $mingw; then
   fi
 fi
 
+# Test ARG_NEWCLOSURE overflow protection (issue #3458)
+# Test 1: Too many function parameters (4097 params triggers the limit)
+echo "Testing function parameter limit..."
+cat > $d/expected <<EOF
+jq: error: too many function parameters or local function definitions (max 4095)
+jq: 1 compile error
+EOF
+$JQ -rn '"def f(\([range(4097) | "a\(.)"] | join(";"))): .; f(\([range(4097)] | join(";")))"' > $d/prog.jq
+$JQ -nf $d/prog.jq 2> $d/out && {
+  echo "Expected compile error for too many parameters"
+  exit 1
+}
+diff $d/out $d/expected
+
+# Test 2: Too many local functions (4097 functions triggers the limit)
+echo "Testing local function limit..."
+cat > $d/expected <<EOF
+jq: error: too many function parameters or local function definitions (max 4095)
+jq: 1 compile error
+EOF
+$JQ -rn '"\([range(4097) | "def f\(.): \(.)"] | join("; ")); \([range(4097) | "f\(.)"] | join(" + "))"' > $d/prog.jq
+$JQ -nf $d/prog.jq 2> $d/out && {
+  echo "Expected compile error for too many local functions"
+  exit 1
+}
+diff $d/out $d/expected
+
 exit 0


### PR DESCRIPTION
…erflow

When closure/subfunction indices overflow into the ARG_NEWCLOSURE flag bit (0x1000 = 4096), it causes:
- NULL pointer dereference in dump_operation() (bytecode.c:109)
- Assertion failure in frame_push() (execute.c:139)

This happens in two scenarios:
1. A single function with >= 4096 parameters
2. Multiple functions with cumulative >= 4096 subfunctions (including lambdas created for each call argument)

This patch adds compile-time checks to reject programs that would overflow:
- Check nclosures per function (parameters)
- Check total nsubfunctions (all defs and lambdas)

Fixes: https://github.com/jqlang/jq/issues/3458