### PR TITLE
Fix @urid corrupting multi-byte UTF-8 characters in its input.

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -662,9 +662,14 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
     const char *errmsg =  "is not a valid uri encoding";
     const char *s = jv_string_value(input);
     while (*s) {
-      if (*s != '%') {
-        line = jv_string_append_buf(line, s++, 1);
-      } else {
+      // Find a contiguous block of non-'%' characters
+      const char *start = s;
+      while (*s && *s != '%') ++s;
+      if (s > start) {
+        line = jv_string_append_buf(line, start, s - start);
+      }
+
+      if (*s == '%') {
         unsigned char unicode[4] = {0};
         int b = 0;
         // check leading bits of first octet to determine length of unicode character

--- a/tests/uri.test
+++ b/tests/uri.test
@@ -19,6 +19,28 @@
 "a%20%CE%BC%20%E2%88%B0%20%F0%9F%98%8E"
 "a \u03bc \u2230 \ud83d\ude0e"
 
+# Check that @urid does not corrupt UTF-8 when no decoding is needed
+@urid
+"Knäckebröd"
+"Knäckebröd"
+
+# Percent-decoding of a two-byte UTF-8 character (U+0435, Cyrillic 'е')
+@urid
+"%D0%B5"
+"е"
+
+# Percent-decoding of a three-byte UTF-8 character (U+2230, '∰')
+@urid
+"%E2%88%B0"
+"∰"
+
+# Percent-decoding of a four-byte UTF-8 character (U+1F60E, '😎')
+@urid
+"%F0%9F%98%8E"
+"😎"
+
+
+
 ### invalid uri strings
 
 # unicode character should be length 4 (not 3)
@@ -36,3 +58,23 @@
 . | try @urid catch .
 "%F0%C0%81%8E"
 "string (\"%F0%C0%81%8E\") is not a valid uri encoding"
+
+# Incomplete percent sequence (missing hex digits)
+. | try @urid catch .
+"%D0"
+"string (\"%D0\") is not a valid uri encoding"
+
+# String ending with a stray '%'
+. | try @urid catch .
+"abc%"
+"string (\"abc%\") is not a valid uri encoding"
+
+# Literal '%' not followed by (hex) digits
+. | try @urid catch .
+"100% satisfaction"
+"string (\"100% satis...) is not a valid uri encoding"
+
+# Overlong UTF-8 encoding (2-byte encoding for '/')
+. | try @urid catch .
+"%C0%AF"
+"string (\"%C0%AF\") is not a valid uri encoding"


### PR DESCRIPTION
When `@urid` processes a string, it copies non‑% characters one byte at a time. This breaks multi‑byte UTF‑8 sequences (e.g., _"Knäckebröd"_ becomes _"Kn��ckebr��d"_) because appending only the first byte of a character creates an invalid intermediate state that `jv_string_append_buf()` immediately replaces with `�`. This can happen for example when a string is unintentionally percent‑decoded twice in a complex jq script.

The fix collects contiguous runs of non‑% bytes and appends them in one operation, preserving UTF‑8 integrity. This is safe because any contiguous run of non‑% bytes starting from a valid position in a UTF‑8 string consists of whole UTF‑8 characters as `%` cannot appear inside a multi‑byte character, so runs always end at character boundaries.

As a happy side effect this also reduces the number of `jv_string_append_buf calls()` in many instances.