### PR TITLE
Refactor tm2jv to handle fractional seconds removing duplicated code

### DIFF
--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1834,6 +1834,10 @@ gmtime
 1425599507
 [2015,2,5,23,51,47,4,63]
 
+gmtime[5]
+1425599507.25
+47.25
+
 # test invalid tm input
 try strftime("%Y-%m-%dT%H:%M:%SZ") catch .
 ["a",1,2,3,4,5,6,7]


### PR DESCRIPTION
This refactors `tm2jv` to remove duplicated code. Also avoids confusion of memory leak of `jv_array_get(jv_copy(a), 5)` (this is not an actual leak, but confusing).
