### PR TITLE
Add missing validity check in `f_strflocaltime` after `f_localtime`

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1803,6 +1803,10 @@ static jv f_strftime(jq_state *jq, jv a, jv b) {
 static jv f_strflocaltime(jq_state *jq, jv a, jv b) {
   if (jv_get_kind(a) == JV_KIND_NUMBER) {
     a = f_localtime(jq, a);
+    if (!jv_is_valid(a)) {
+      jv_free(b);
+      return a;
+    }
   } else if (jv_get_kind(a) != JV_KIND_ARRAY) {
     return ret_error2(a, b, jv_string("strflocaltime/1 requires parsed datetime inputs"));
   }


### PR DESCRIPTION
This PR fixes an assertion error bug of `strflocaltime`. If `f_localtime` fails, it should return the error. For example, `99999999999999999 | strflocaltime("%Y")`. Didn't add a test case for this because I'm not sure how to make `localtime_r` fail regardless of the platform.
