### PR TITLE
Fix tonumber and toboolean to reject strings with embedded null bytes

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -446,6 +446,10 @@ static jv f_tonumber(jq_state *jq, jv input) {
   }
   if (jv_get_kind(input) == JV_KIND_STRING) {
     const char* s = jv_string_value(input);
+    int len = jv_string_length_bytes(jv_copy(input));
+    if ((size_t)len != strlen(s)) {
+      return type_error(input, "cannot be parsed as a number");
+    }
 #ifdef USE_DECNUM
     jv number = jv_number_with_literal(s);
     if (jv_get_kind(number) == JV_KIND_INVALID) {
@@ -471,6 +475,10 @@ static jv f_toboolean(jq_state *jq, jv input) {
   }
   if (jv_get_kind(input) == JV_KIND_STRING) {
     const char *s = jv_string_value(input);
+    int len = jv_string_length_bytes(jv_copy(input));
+    if ((size_t)len != strlen(s)) {
+      return type_error(input, "cannot be parsed as a boolean");
+    }
     if (strcmp(s, "true") == 0) {
       jv_free(input);
       return jv_true();

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -698,6 +698,10 @@ null
 4
 15
 
+"123\u0000456" | try tonumber catch .
+null
+"string (\"123\\u0000456\") cannot be parsed as a number"
+
 map(toboolean)
 ["false","true",false,true]
 [false,true,false,true]
@@ -712,6 +716,11 @@ map(toboolean)
 "string (\"falsee\") cannot be parsed as a boolean"
 "array ([]) cannot be parsed as a boolean"
 "object ({}) cannot be parsed as a boolean"
+
+"true\u0000x", "false\u0000" | try toboolean catch .
+null
+"string (\"true\\u0000x\") cannot be parsed as a boolean"
+"string (\"false\\u0000\") cannot be parsed as a boolean"
 
 [{"a":42},.object,10,.num,false,true,null,"b",[1,4]] | .[] as $x | [$x == .[]]
 {"object": {"a":42}, "num":10.0}


### PR DESCRIPTION
This PR fixes some filters with embedded null bytes.
