### PR TITLE
Fix crash when importing a module with errors twice

### DIFF
--- a/src/linker.c
+++ b/src/linker.c
@@ -366,11 +366,13 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
       program = block_bind_self(program, OP_IS_CALL_PSEUDO);
     }
   }
-  state_idx = lib_state->ct++;
-  lib_state->names = jv_mem_realloc(lib_state->names, lib_state->ct * sizeof(const char *));
-  lib_state->defs = jv_mem_realloc(lib_state->defs, lib_state->ct * sizeof(block));
-  lib_state->names[state_idx] = strdup(jv_string_value(lib_path));
-  lib_state->defs[state_idx] = program;
+  if (nerrors == 0) {
+    state_idx = lib_state->ct++;
+    lib_state->names = jv_mem_realloc(lib_state->names, lib_state->ct * sizeof(const char *));
+    lib_state->defs = jv_mem_realloc(lib_state->defs, lib_state->ct * sizeof(block));
+    lib_state->names[state_idx] = strdup(jv_string_value(lib_path));
+    lib_state->defs[state_idx] = program;
+  }
 out:
   *out_block = program;
   jv_free(lib_path);


### PR DESCRIPTION
When a module fails to parse as a library, `load_library` cached the
invalid block. A second import/include of the same module would find
the cached invalid block and pass it to `block_bind_library`,
triggering the assertion failure. Skip caching the block when there
are parse errors to avoid this problem. Fixes #3126.
