### PR TITLE
fix jq_fuzz_parse_stream: use iterative parser API for streaming mode

### DIFF
--- a/tests/jq_fuzz_parse_stream.c
+++ b/tests/jq_fuzz_parse_stream.c
@@ -5,15 +5,27 @@
 #include "jv.h"
 
 int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
-  // Creat null-terminated string
+  // Create null-terminated string
   char *null_terminated = (char *)malloc(size + 1);
   memcpy(null_terminated, (char *)data, size);
   null_terminated[size] = '\0';
 
-  // Fuzzer entrypoint
-  jv res = jv_parse_custom_flags(null_terminated, JV_PARSE_STREAMING);
-  jv_free(res);
-  
+  // Use the iterative jv_parser API for streaming mode.
+  // The single-shot jv_parse_custom_flags() returns "Unexpected extra JSON
+  // values" for any compound JSON in streaming mode, because the streaming
+  // parser produces multiple tokens but the single-shot API expects exactly
+  // one value.
+  jv_parser *parser = jv_parser_new(JV_PARSE_STREAMING);
+  jv_parser_set_buf(parser, null_terminated, (int)size, 0);
+
+  jv value;
+  while (jv_is_valid(value = jv_parser_next(parser))) {
+    jv_free(value);
+  }
+  jv_free(value);
+
+  jv_parser_free(parser);
+
   // Free the null-terminated string
   free(null_terminated);
 


### PR DESCRIPTION
## Summary

`jq_fuzz_parse_stream` uses the single-shot `jv_parse_custom_flags()` API with `JV_PARSE_STREAMING`, but this API **always returns an error** for any compound JSON input in streaming mode. The streaming parser's core state machine is never exercised.

## Problem

`jv_parse_custom_flags` delegates to `jv_parse_sized_custom_flags` ([jv_parse.c:865](https://github.com/jqlang/jq/blob/master/src/jv_parse.c#L865)), which internally calls `jv_parser_next` at most **twice**:

```c
jv value = jv_parser_next(&parser);       // first token
if (jv_is_valid(value)) {
    jv next = jv_parser_next(&parser);     // second token
    if (jv_is_valid(next)) {
        // "Unexpected extra JSON values" → return error
    }
}
```

In streaming mode, any compound JSON (objects, arrays) produces **multiple** streaming tokens (path-value pairs). The single-shot API gets the first token, finds a second valid token, and returns `"Unexpected extra JSON values"`. The fuzzer always gets an error for any interesting input — the streaming parser's state machine, token iteration, and path tracking are never tested.

Only bare scalars (`1`, `true`, `"hello"`) succeed, but those don't exercise the streaming logic at all.

## Evidence

Built both original and fixed fuzzers with coverage instrumentation, ran each for 60 seconds from empty corpus, and compared function-level execution counts via `llvm-cov export`:

| Function | Original | Fixed | Change |
|----------|----------|-------|--------|
| `jv_parse_custom_flags` (single-shot) | 30,954,177 | **0** | Fixed uses correct API |
| `jv_parser_new` (iterative) | **0** | 45,143,742 | Fixed uses correct API |
| `stream_token` | 1,624,840 | **2,387,944** | **+47%** |
| `value` (JSON values processed) | 745,672 | **1,597,681** | **+114%** |
| `found_string` (strings parsed) | 31,980 | **560,331** | **+17.5x** |

The original calls `jv_parser_next` ~1.02 times per iteration (at most twice, then error). The fixed version iterates through all tokens, processing 17.5x more strings and 2.1x more JSON values.

## Fix

Replace the single-shot API with the iterative `jv_parser` API, matching the pattern used by `jq --stream` in `main.c`:

```diff
-  jv res = jv_parse_custom_flags(null_terminated, JV_PARSE_STREAMING);
-  jv_free(res);
+  jv_parser *parser = jv_parser_new(JV_PARSE_STREAMING);
+  jv_parser_set_buf(parser, null_terminated, (int)size, 0);
+  jv value;
+  while (jv_is_valid(value = jv_parser_next(parser))) {
+    jv_free(value);
+  }
+  jv_free(value);
+  jv_parser_free(parser);
```