### PR TITLE
Fix jv_cmp to treat NaN==NaN as equal for sort and bsearch

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -595,7 +595,9 @@ int jv_cmp(jv a, jv b) {
     break;
 
   case JV_KIND_NUMBER: {
-    if (jvp_number_is_nan(a)) {
+    if (jvp_number_is_nan(a) && jvp_number_is_nan(b)) {
+      r = 0;
+    } else if (jvp_number_is_nan(a)) {
       r = jv_cmp(jv_null(), jv_copy(b));
     } else if (jvp_number_is_nan(b)) {
       r = jv_cmp(jv_copy(a), jv_null());

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1681,6 +1681,17 @@ unique
 []
 []
 
+# NaN comparison: two NaNs compare equal in jv_cmp (for sort, bsearch, etc.)
+# bsearch: old logic never matches (jv_cmp(nan,nan)<0), new logic finds it
+bsearch(nan)
+[nan, 1, 2]
+0
+
+# sort regression: compare only x-order to avoid NaN equality pitfalls in test harness
+sort | map(.x)
+[{"x":2,"v":nan},{"x":0,"v":nan},{"x":1,"v":1}]
+[0,2,1]
+
 [min, max, min_by(.[1]), max_by(.[1]), min_by(.[2]), max_by(.[2])]
 [[4,2,"a"],[3,1,"a"],[2,4,"a"],[1,3,"a"]]
 [[1,3,"a"],[4,2,"a"],[3,1,"a"],[2,4,"a"],[4,2,"a"],[1,3,"a"]]


### PR DESCRIPTION
Previously jv_cmp(nan, nan) did not return 0, causing bsearch to never find NaN and sort to behave inconsistently. Now two NaNs compare equal.