### PR TITLE
Add Solaris support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,12 @@ dnl Created autoconf implementation thompson@dtosolutions, 26NOV12
 AC_PREREQ([2.65])
 AC_CONFIG_AUX_DIR([config])
 AC_USE_SYSTEM_EXTENSIONS
+
+dnl Prefer GNU make on Solaris where /usr/bin/make is not suitable
+AS_IF([test -z "$MAKE"], [
+  AS_CASE(["`uname -s`"], [SunOS], [MAKE=/usr/gnu/bin/make])
+])
+
 AM_INIT_AUTOMAKE([1.11.2 subdir-objects parallel-tests foreign -Wall])
 AM_SILENT_RULES([yes])
 AM_PROG_AR

--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,14 @@ AC_SUBST(onig_LDFLAGS)
 AM_CONDITIONAL([BUILD_ONIGURUMA], [test "x$build_oniguruma" = xyes])
 AM_CONDITIONAL([WITH_ONIGURUMA], [test "x$with_oniguruma" != xno])
 
+dnl On Solaris, strptime clears the tm structure before parsing. This breaks the
+dnl sentinel logic in builtin.c, which then incorrectly assumes that strptime set
+dnl tm_wday and tm_yday. Defining _STRPTIME_DONTZERO disables that behavior.
+AS_IF([test "x`uname -s 2>/dev/null`" = "xSunOS"], [
+  CPPFLAGS="$CPPFLAGS -D_STRPTIME_DONTZERO"
+])
+
+
 AC_CONFIG_MACRO_DIRS([config/m4 m4])
 AC_CONFIG_FILES([Makefile libjq.pc])
 AC_OUTPUT

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1783,21 +1783,29 @@ static jv f_strftime(jq_state *jq, jv a, jv b) {
   int fmt_not_empty = *fmt != '\0';
   size_t max_size = strlen(fmt) + 100;
   char *buf = jv_mem_alloc(max_size);
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__sun)
   /* Apple Libc (as of version 1669.40.2) contains a bug which causes it to
    * ignore the `tm.tm_gmtoff` in favor of the global timezone. To print the
    * proper timezone offset we temporarily switch the TZ to UTC. */
   char *tz = (tz = getenv("TZ")) != NULL ? strdup(tz) : NULL;
   setenv("TZ", "UTC", 1);
 #endif
+#if defined(__sun)
+  /* Solaris moreover needs call to tzset to take the changed environment into
+   * account ... */
+  tzset();
+#endif
   size_t n = strftime(buf, max_size, fmt, &tm);
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__sun)
   if (tz) {
     setenv("TZ", tz, 1);
     free(tz);
   } else {
     unsetenv("TZ");
   }
+#endif
+#if defined(__sun)
+  tzset();
 #endif
   jv_free(b);
   /* POSIX doesn't provide errno values for strftime() failures; weird */

--- a/tests/shtest
+++ b/tests/shtest
@@ -690,7 +690,7 @@ EOF
     echo "WARNING: Not testing localization"
   else
     dt1=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
-    dt2=$(LC_ALL=$l jq -nr 'now | strflocaltime("%a %d %b %Y at %H:%M:%S")')
+    dt2=$(LC_ALL=$l $JQ -nr 'now | strflocaltime("%a %d %b %Y at %H:%M:%S")')
     dt3=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
     if [ "$dt1" != "$dt2" ] && [ "$dt2" != "$dt3" ]; then
       echo "jq does not honor LC_ALL environment variable ($dt1, $dt2, $dt3)"

--- a/tests/shtest
+++ b/tests/shtest
@@ -4,13 +4,20 @@
 
 msys=false
 mingw=false
+sunos=false
 case "$(uname -s)" in
 MSYS*)  msys=true;;
 MINGW*) mingw=true;;
+SunOS*) sunos=true;;
 esac
 
 JQ_NO_B=$JQ
 JQ="$JQ -b"
+
+# On Solaris, GNU tools are available in /usr/gnu. This script should prefer
+# them over the native tools, because the native versions may lack some
+# command-line options the script relies on.
+$sunos && PATH="/usr/gnu/bin:$PATH"
 
 PATH=$JQBASEDIR:$PATH $JQBASEDIR/tests/jq-f-test.sh > /dev/null
 
@@ -603,16 +610,18 @@ cmp $d/color $d/expect
 echo 'Failed to set $JQ_COLORS' > $d/expect_warning
 $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/expect
 for colors in '/' '[30' '30m' '30:31m:32' '30:*:31' 'invalid'; do
-  JQ_COLORS=$colors \
-    $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
+  export JQ_COLORS=$colors
+  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
   cmp $d/color $d/expect
   cmp $d/warning $d/expect_warning
 done
+unset JQ_COLORS
 
 # Check $NO_COLOR
 test_no_color=true
 $msys  && test_no_color=false
 $mingw && test_no_color=false
+$sunos && test_no_color=false
 if $test_no_color && command -v script >/dev/null 2>&1; then
   if script -qc echo /dev/null >/dev/null 2>&1; then
     faketty() { script -qec "$*" /dev/null; }


### PR DESCRIPTION
I love jq :) So while updating the version we ship in Solaris I have tried to modify stuff to make everything work out of the box. Just

```
autoreconf -fiv
./configure
gmake
gmake check
```

I also went ahead and created Solaris test action should you be interested in having it too. The changes are not extensive and I have tried to comment them nicely in each commit. Hopefully that's enough.

Thanks for jq!