### PR TITLE
Use `//` instead of `//=` in from_entries definition

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -39,7 +39,8 @@ def recurse(f; cond): def r: ., (f | select(cond) | r); r;
 def recurse: recurse(.[]?);
 
 def to_entries: [keys_unsorted[] as $k | {key: $k, value: .[$k]}];
-def from_entries: map({(.key // .Key // .name // .Name): (if has("value") then .value else .Value end)}) | add | .//={};
+def from_entries: map({ (.key // .Key // .name // .Name):
+  if has("value") then .value else .Value end }) | add // {};
 def with_entries(f): to_entries | map(f) | from_entries;
 def reverse: [.[length - 1 - range(0;length)]];
 def indices($i): if type == "array" and ($i|type) == "array" then .[$i]


### PR DESCRIPTION
Just a nit pick improvement in `from_entries/0`.
