### PR TITLE
Fix: alternate operator (//) precedence (#3507)

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -100,8 +100,8 @@ struct lexer_param;
 %precedence FUNCDEF
 %right '|'
 %left ','
-%right "//"
 %nonassoc '=' SETPIPE SETPLUS SETMINUS SETMULT SETDIV SETMOD SETDEFINEDOR
+%right "//"
 %left OR
 %left AND
 %nonassoc NEQ EQ '<' '>' LESSEQ GREATEREQ


### PR DESCRIPTION
Fixes #3507

**Description:**
The alternate operator `//` was declared with lower precedence than the assignment operator `=`, causing expressions like `.[0] = null // 2` to be parsed incorrectly as `(.[0] = null) // 2`. 

This PR moves the `%right "//"` directive below the `%nonassoc '='` block in `src/parser.y` to bump the precedence of `//` above assignment. 
