### PR TITLE
fix(jv): tighten overflow guard in jvp_string_copy_replace_bad

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -1115,7 +1115,7 @@ static jv jvp_string_copy_replace_bad(const char* data, uint32_t length) {
 
   // worst case: all bad bytes, each becomes a 3-byte U+FFFD
   uint64_t maxlength = (uint64_t)length * 3 + 1;
-  if (maxlength >= INT_MAX) {
+  if (maxlength >= INT_MAX - sizeof(jvp_string) / 2) {
     return jv_invalid_with_msg(jv_string("String too long"));
   }
 


### PR DESCRIPTION
## What

Commit 46d1da30 ("Tighten string length bounds") updated the allocation-overflow guard in `jvp_string_append` and `jv_string_repeat` from

```c
if (len >= INT_MAX)
```

to

```c
if (len >= INT_MAX - sizeof(jvp_string) / 2)
```

because `jvp_string_alloc(size)` allocates `sizeof(jvp_string) + size + 1` bytes, so a `size` near `INT_MAX` overflows the addition.

`jvp_string_copy_replace_bad` was not updated in that commit and still uses the old `>= INT_MAX` threshold, leaving it vulnerable to the same integer overflow when `maxlength` is just below `INT_MAX`.

## Fix

Apply the same tightened threshold to `jvp_string_copy_replace_bad`, matching the two sibling functions:

```diff
-  if (maxlength >= INT_MAX) {
+  if (maxlength >= INT_MAX - sizeof(jvp_string) / 2) {
```

## Verification

Grepped all three string-length guards in `src/jv.c` after the change — all now use `INT_MAX - sizeof(jvp_string) / 2`:

- `jvp_string_copy_replace_bad` (line 1118) — fixed here
- `jvp_string_append` (line 1181) — already tightened by 46d1da30
- `jv_string_repeat` (line 1382) — already tightened by 46d1da30

Build was skipped (heavy autoconf toolchain not in CI environment); the change is a 1-line guard tightening with no logic change beyond the threshold.