### PR TITLE
shtest: skip locale test if date lacks locale support

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -712,8 +712,13 @@ EOF
   if [ -z "$l" ]; then
     echo "WARNING: Not testing localization"
   else
-    dt_c=$(LC_ALL=C date -d '20260101 12:00:00')
-    dt_l=$(LC_ALL=$l date -d '20260101 12:00:00')
+    if date -v1d >/dev/null 2>&1; then
+      dt_c=$(LC_ALL=c date -j -f '%Y%m%d %H:%M:%S' '20260101 12:00:00')
+      dt_l=$(LC_ALL=$l date -j -f '%Y%m%d %H:%M:%S' '20260101 12:00:00')
+    else
+      dt_c=$(LC_ALL=c date -d '20260101 12:00:00')
+      dt_l=$(LC_ALL=$l date -d '20260101 12:00:00')
+    fi
     if [ "$dt_c" = "$dt_l" ]; then
       echo "WARNING: Date does not produce locale-dependent output for $l, skipping localization test"
     else

--- a/tests/shtest
+++ b/tests/shtest
@@ -711,17 +711,15 @@ $locales
 EOF
   if [ -z "$l" ]; then
     echo "WARNING: Not testing localization"
+  elif [ "$(LC_ALL=C date +%a%b)" = "$(LC_ALL=$l date +%a%b)" ]; then
+    echo "WARNING: Date does not produce locale-dependent output for $l, skipping localization test"
   else
-    if [ "$(LC_ALL=C date +%a%b)" = "$(LC_ALL=$l date +%a%b)" ]; then
-      echo "WARNING: Date does not produce locale-dependent output for $l, skipping localization test"
-    else
-      dt1=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
-      dt2=$(LC_ALL=$l $JQ -nr 'now | strflocaltime("%a %d %b %Y at %H:%M:%S")')
-      dt3=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
-      if [ "$dt1" != "$dt2" ] && [ "$dt2" != "$dt3" ]; then
-        echo "jq does not honor LC_ALL environment variable ($dt1, $dt2, $dt3)"
-        exit 1
-      fi
+    dt1=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
+    dt2=$(LC_ALL=$l $JQ -nr 'now | strflocaltime("%a %d %b %Y at %H:%M:%S")')
+    dt3=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
+    if [ "$dt1" != "$dt2" ] && [ "$dt2" != "$dt3" ]; then
+      echo "jq does not honor LC_ALL environment variable ($dt1, $dt2, $dt3)"
+      exit 1
     fi
   fi
 fi

--- a/tests/shtest
+++ b/tests/shtest
@@ -712,12 +712,18 @@ EOF
   if [ -z "$l" ]; then
     echo "WARNING: Not testing localization"
   else
-    dt1=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
-    dt2=$(LC_ALL=$l $JQ -nr 'now | strflocaltime("%a %d %b %Y at %H:%M:%S")')
-    dt3=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
-    if [ "$dt1" != "$dt2" ] && [ "$dt2" != "$dt3" ]; then
-      echo "jq does not honor LC_ALL environment variable ($dt1, $dt2, $dt3)"
-      exit 1
+    dt_c=$(LC_ALL=C date -d '20260101 12:00:00')
+    dt_l=$(LC_ALL=$l date -d '20260101 12:00:00')
+    if [ "$dt_c" = "$dt_l" ]; then
+      echo "WARNING: Date does not produce locale-dependent output for $l, skipping localization test"
+    else
+      dt1=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
+      dt2=$(LC_ALL=$l $JQ -nr 'now | strflocaltime("%a %d %b %Y at %H:%M:%S")')
+      dt3=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
+      if [ "$dt1" != "$dt2" ] && [ "$dt2" != "$dt3" ]; then
+        echo "jq does not honor LC_ALL environment variable ($dt1, $dt2, $dt3)"
+        exit 1
+      fi
     fi
   fi
 fi

--- a/tests/shtest
+++ b/tests/shtest
@@ -712,14 +712,7 @@ EOF
   if [ -z "$l" ]; then
     echo "WARNING: Not testing localization"
   else
-    if date -v1d >/dev/null 2>&1; then
-      dt_c=$(LC_ALL=c date -j -f '%Y%m%d %H:%M:%S' '20260101 12:00:00')
-      dt_l=$(LC_ALL=$l date -j -f '%Y%m%d %H:%M:%S' '20260101 12:00:00')
-    else
-      dt_c=$(LC_ALL=c date -d '20260101 12:00:00')
-      dt_l=$(LC_ALL=$l date -d '20260101 12:00:00')
-    fi
-    if [ "$dt_c" = "$dt_l" ]; then
+    if [ "$(LC_ALL=C date +%a%b)" = "$(LC_ALL=$l date +%a%b)" ]; then
       echo "WARNING: Date does not produce locale-dependent output for $l, skipping localization test"
     else
       dt1=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')


### PR DESCRIPTION
The locale test uses the date util as a reference to verify that jq's strflocaltime honors locales. On systems where date does not produce locale-dependent output (e.g. Ubuntu's Rust coreutils which ignores LC_ALL/LC_TIME), the test fails.

Skip the test if the date util lacks locale support.