### PR TITLE
Advance past the whole codepoint after a zero-width regex match

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1086,8 +1086,14 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
         onig_foreach_name(reg, f_match_name_iter, &captures);
         match = jv_object_set(match, jv_string("captures"), captures);
         result = jv_array_append(result, match);
-        // ensure '"qux" | match("(?=u)"; "g")' matches just once
-        start = (const UChar*)(input_string+region->end[0]+1);
+        // ensure '"qux" | match("(?=u)"; "g")' matches just once; advance the
+        // search start past the whole codepoint, not a single byte, so we don't
+        // land in the middle of a multibyte character (which would yield a
+        // spurious duplicate match at the same offset).
+        start = (const UChar*)(input_string + region->end[0] +
+            ((size_t)region->end[0] < length
+                 ? jvp_utf8_decode_length(input_string[region->end[0]])
+                 : 1));
         continue;
       }
 

--- a/tests/onig.test
+++ b/tests/onig.test
@@ -11,6 +11,19 @@
 "ab"
 [{"offset":0,"length":0,"string":"","captures":[]},{"offset":1,"length":0,"string":"","captures":[]},{"offset":2,"length":0,"string":"","captures":[]}]
 
+# global zero-width matches must not land inside a multibyte character
+[match(""; "g") | .offset]
+"aé€🚀b"
+[0,1,2,3,4,5]
+
+gsub(""; "-")
+"aé"
+"-a-é-"
+
+[splits("")]
+"aé"
+["","a","é",""]
+
 [match("a"; "gi")]
 "āáàä"
 []


### PR DESCRIPTION
### What / why

After a **zero-width** match in a global (`"g"`) regex, `f_match` advanced the search start by **one byte** to avoid re-matching at the same position. Oniguruma runs in `ONIG_ENCODING_UTF8`, so on a multibyte character that `+1` byte lands *inside* the next codepoint, and the next `onig_search` finds a spurious extra zero-width match at a duplicated offset — one bogus match per multibyte character. `match`, `gsub`, `sub`, `splits`, `split/2` and `scan` were all affected on multibyte input:

```console
$ echo '"aé"'     | jq -c '[match("";"g")|.offset]'   # before [0,1,2,2]   after [0,1,2]
$ echo '"héllo"'  | jq -c 'gsub("(?=.)";"-")'         # before "-h-é--l-l-o"   after "-h-é-l-l-o"
$ echo '"aé"'     | jq -c '[splits("")]'              # before ["","a","é","",""]   after ["","a","é",""]
```

### Fix

Advance past the whole codepoint using `jvp_utf8_decode_length` (already used elsewhere in `f_match`) rather than a single byte, so the search start can never land inside a multibyte character. This is the multibyte tail of #2565 — the ASCII case it fixed (and its test) still pass.

### Tests

Added multibyte regression cases to `tests/onig.test` (offsets over 2/3/4-byte chars incl. `€`/`🚀`, `gsub`, `splits`). They fail on the previous code and pass now. `./jq --run-tests tests/onig.test` → 50/50; full `make check` green.

Fixes #3585
