### PR TITLE
Propagate break through destructuring alternative operator

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -519,7 +519,7 @@ jv jq_next(jq_state *jq) {
       if (raising) {
         jv_free(max);
         goto do_backtrack;
-      } 
+      }
       if (jv_get_kind(*var) != JV_KIND_NUMBER ||
           jv_get_kind(max) != JV_KIND_NUMBER) {
         set_error(jq, jv_invalid_with_msg(jv_string_fmt("Range bounds must be numeric")));
@@ -882,15 +882,16 @@ jv jq_next(jq_state *jq) {
         jv_free(stack_pop(jq));
         goto do_backtrack;
       }
-      // `try EXP ...` exception caught in EXP
-      // DESTRUCTURE_ALT doesn't want the error message on the stack,
-      // as we would just want to throw it away anyway.
-      if (opcode != ON_BACKTRACK(DESTRUCTURE_ALT)) {
-        jv_free(stack_pop(jq)); // free the input
-        stack_push(jq, jv_invalid_get_msg(jq->error));  // push the error's message
-      } else {
-        jv_free(jq->error);
-      }
+
+      // Propagate break's control-flow error to its label.
+      jv msg = jv_invalid_get_msg(jv_copy(jq->error));
+      int is_break = jv_get_kind(msg) == JV_KIND_OBJECT &&
+                     jv_object_has(jv_copy(msg), jv_string("__jq"));
+      jv_free(msg);
+      if (is_break)
+        goto do_backtrack;
+
+      jv_free(jq->error);
       jq->error = jv_null();
       uint16_t offset = *pc++;
       pc += offset;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1042,6 +1042,10 @@ null
 [5]
 6
 
+label $out | . as [$a] ?// $b | {$a, $b}, break $out
+[7]
+{"a":7,"b":null}
+
 . as $dot|any($dot[];not)
 [1,2,3,4,true,false,1,2,3,4,5]
 true


### PR DESCRIPTION
`break $label` is implemented as an error whose message is the label
object, so the destructuring alternative operator (`?//`) caught it on
backtracking and retried the next pattern instead of letting it reach
its label. Detect break's control-flow error and propagate it.
