### PR TITLE
Add jv_mem_reallocarray for overflow-safe array reallocation

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -449,6 +449,8 @@ pthread_setspecific(pthread_key_t key, void *value)
         } else {
             new_num = (values.values_num + values.values_num / 2);
         }
+        if (new_num > SIZE_MAX / sizeof(void *))
+            return ENOMEM;
         new_values = realloc(values.values, sizeof(void *) * new_num);
         if (new_values == NULL)
             return ENOMEM;
@@ -2021,7 +2023,7 @@ void jv_free(jv j) {
           jvp_array* arr = jvp_array_ptr(j);
           if (len + arr->length > cap) {
             cap = (len + arr->length) * 2;
-            pending = jv_mem_realloc(pending, cap * sizeof(jv));
+            pending = jv_mem_reallocarray(pending, cap, sizeof(jv));
           }
           for (int i = 0; i < arr->length; i++)
             pending[len++] = arr->elements[i];
@@ -2033,7 +2035,7 @@ void jv_free(jv j) {
           int sz = jvp_object_size(j);
           if (len + sz > cap) {
             cap = (len + sz) * 2;
-            pending = jv_mem_realloc(pending, cap * sizeof(jv));
+            pending = jv_mem_reallocarray(pending, cap, sizeof(jv));
           }
           for (int i = 0; i < sz; i++) {
             struct object_slot* slot = jvp_object_get_slot(j, i);
@@ -2049,7 +2051,7 @@ void jv_free(jv j) {
         if (JVP_HAS_FLAGS(j, JVP_FLAGS_INVALID_MSG) && jvp_refcnt_dec(j.u.ptr)) {
           if (len + 1 > cap) {
             cap = (len + 1) * 2;
-            pending = jv_mem_realloc(pending, cap * sizeof(jv));
+            pending = jv_mem_reallocarray(pending, cap, sizeof(jv));
           }
           pending[len++] = ((jvp_invalid*)j.u.ptr)->errmsg;
           jv_mem_free(j.u.ptr);

--- a/src/jv_alloc.c
+++ b/src/jv_alloc.c
@@ -187,3 +187,14 @@ void* jv_mem_realloc(void* p, size_t sz) {
   }
   return p;
 }
+
+void* jv_mem_reallocarray(void* p, size_t nmemb, size_t sz) {
+  if (sz && nmemb > SIZE_MAX / sz) {
+    memory_exhausted();
+  }
+  p = realloc(p, nmemb * sz);
+  if (!p) {
+    memory_exhausted();
+  }
+  return p;
+}

--- a/src/jv_alloc.h
+++ b/src/jv_alloc.h
@@ -11,5 +11,6 @@ char* jv_mem_strdup(const char *);
 char* jv_mem_strdup_unguarded(const char *);
 void jv_mem_free(void*);
 __attribute__((warn_unused_result)) void* jv_mem_realloc(void*, size_t);
+__attribute__((warn_unused_result)) void* jv_mem_reallocarray(void*, size_t, size_t);
 
 #endif

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -149,7 +149,7 @@ static void push(struct jv_parser* p, jv v) {
   assert(p->stackpos <= p->stacklen);
   if (p->stackpos == p->stacklen) {
     p->stacklen = p->stacklen * 2 + 10;
-    p->stack = jv_mem_realloc(p->stack, p->stacklen * sizeof(jv));
+    p->stack = jv_mem_reallocarray(p->stack, p->stacklen, sizeof(jv));
   }
   assert(p->stackpos < p->stacklen);
   p->stack[p->stackpos++] = v;

--- a/src/linker.c
+++ b/src/linker.c
@@ -370,7 +370,7 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
     // import "foo" as $bar;
     program = gen_const_global(jv_copy(data), as);
     state_idx = lib_state->ct++;
-    lib_state->entries = jv_mem_realloc(lib_state->entries, lib_state->ct * sizeof(struct lib_entry));
+    lib_state->entries = jv_mem_reallocarray(lib_state->entries, lib_state->ct, sizeof(struct lib_entry));
     lib_state->entries[state_idx].name = strdup(jv_string_value(lib_path));
     lib_state->entries[state_idx].def = program;
     lib_state->entries[state_idx].loading = 0;
@@ -383,7 +383,7 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
       // Register the library before processing its dependencies so that
       // circular imports can be detected.
       state_idx = lib_state->ct++;
-      lib_state->entries = jv_mem_realloc(lib_state->entries, lib_state->ct * sizeof(struct lib_entry));
+      lib_state->entries = jv_mem_reallocarray(lib_state->entries, lib_state->ct, sizeof(struct lib_entry));
       lib_state->entries[state_idx].name = strdup(jv_string_value(lib_path));
       lib_state->entries[state_idx].def = gen_noop();
       lib_state->entries[state_idx].loading = 1;


### PR DESCRIPTION
Add `jv_mem_reallocarray(ptr, count, size)` which checks for integer overflow in `count * size` before calling `realloc`. This prevents allocating an undersized buffer when the product wraps around (CWE-190 → CWE-122).

### Changes

**New API** (`jv_alloc.h` / `jv_alloc.c`):
- `jv_mem_reallocarray(void *p, size_t nmemb, size_t sz)` — checked realloc that aborts via `memory_exhausted()` on overflow or allocation failure, following the same pattern as the existing `jv_mem_calloc`.

**Converted sites** (7 total):

| File | Sites | Description |
|------|-------|-------------|
| `jv.c` | 3 | Pending array growth in `jv_free` (deferred object/array frees) |
| `jv.c` | 1 | Thread-local values array (inline overflow check, returns `ENOMEM`) |
| `linker.c` | 2 | Library entry table growth during module loading |
| `jv_parse.c` | 1 | Parser value stack growth during JSON parsing |

All conversions are mechanical. The `jv_parse.c` and `jv.c` sites process untrusted input (JSON data, library paths), making the overflow check particularly important.